### PR TITLE
Deprecating several abstract classes

### DIFF
--- a/GeoFeatures/GFLineString.h
+++ b/GeoFeatures/GFLineString.h
@@ -2,6 +2,7 @@
 *   GFLineString.h
 *
 *   Copyright 2015 The Climate Corporation
+*   Copyright 2015 Tony Stone
 *
 *   Licensed under the Apache License, Version 2.0 (the "License");
 *   you may not use this file except in compliance with the License.
@@ -16,10 +17,16 @@
 *   limitations under the License.
 *
 *   Created by Tony Stone on 6/4/15.
+*
+*   MODIFIED 2015 BY Tony Stone. Modifications licensed under Apache License, Version 2.0.
+*
 */
 
 #import <Foundation/Foundation.h>
 #import "GFLineStringAbstract.h"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 /**
  * @class       GFLineString
@@ -30,6 +37,8 @@
  * @date        6/14/15
  */
 @interface GFLineString : GFLineStringAbstract
+
+#pragma clang diagnostic pop
 
     /**
     * Initialize this geometry with the given WKT (Well-Known-Text) string.

--- a/GeoFeatures/GFLineStringAbstract.h
+++ b/GeoFeatures/GFLineStringAbstract.h
@@ -2,6 +2,7 @@
 *   GFLineStringAbstract.h
 *
 *   Copyright 2015 The Climate Corporation
+*   Copyright 2015 Tony Stone
 *
 *   Licensed under the Apache License, Version 2.0 (the "License");
 *   you may not use this file except in compliance with the License.
@@ -16,23 +17,29 @@
 *   limitations under the License.
 *
 *   Created by Tony Stone on 6/6/15.
+*
+*   MODIFIED 2015 BY Tony Stone. Modifications licensed under Apache License, Version 2.0.
+*
 */
 
 #import <Foundation/Foundation.h>
 #import "GFGeometry.h"
 
 /**
- * @class       GFLineStringAbstract
- *
- * @brief       An Abstract LineString implementation.
- *
- * An Abstract LineString implementation which should not
- * be instantiated on it's own.
- *
- * @warning Do not instantiate this abstract class.
- *
- * @author      Tony Stone
- * @date        6/6/15
- */
+* @class       GFLineStringAbstract
+*
+* @brief       An Abstract LineString implementation.
+*
+* An Abstract LineString implementation which should not
+* be instantiated on it's own.
+*
+* @warning Do not instantiate this abstract class.
+*
+* @deprecated This class will be removed in v2, please don't directly rely on it at this point.
+*
+* @author      Tony Stone
+* @date        6/6/15
+*/
+__deprecated_msg("This class will be removed in v2, please don't directly rely on it at this point.")
 @interface GFLineStringAbstract : GFGeometry
 @end

--- a/GeoFeatures/GFLineStringAbstract.mm
+++ b/GeoFeatures/GFLineStringAbstract.mm
@@ -36,7 +36,12 @@
 
 namespace gf = geofeatures::internal;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 @implementation GFLineStringAbstract (Protected)
+
+#pragma clang diagnostic pop
 
     - (id) init {
         NSAssert(![[self class] isMemberOfClass: [GFLineStringAbstract class]], @"Abstract class %@ can not be instantiated.  Please use one of the subclasses instead.", NSStringFromClass([self class]));

--- a/GeoFeatures/GFMultiLineString.h
+++ b/GeoFeatures/GFMultiLineString.h
@@ -2,6 +2,7 @@
 *   GFMultiLineString.h
 *
 *   Copyright 2015 The Climate Corporation
+*   Copyright 2015 Tony Stone
 *
 *   Licensed under the Apache License, Version 2.0 (the "License");
 *   you may not use this file except in compliance with the License.
@@ -16,11 +17,17 @@
 *   limitations under the License.
 *
 *   Created by Tony Stone on 6/4/15.
+*
+*   MODIFIED 2015 BY Tony Stone. Modifications licensed under Apache License, Version 2.0.
+*
 */
 
 #import <Foundation/Foundation.h>
+#import "GFLineString.h"
 #import "GFLineStringAbstract.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 /**
  * @class       GFMultiLineString
@@ -33,6 +40,8 @@
  * @date        6/4/15
  */
 @interface GFMultiLineString : GFLineStringAbstract
+
+#pragma clang diagnostic pop
 
     /**
     * Initialize this geometry with the given WKT (Well-Known-Text) string.

--- a/GeoFeatures/GFMultiPoint.h
+++ b/GeoFeatures/GFMultiPoint.h
@@ -2,6 +2,7 @@
 *   GFMultiPoint.h
 *
 *   Copyright 2015 The Climate Corporation
+*   Copyright 2015 Tony Stone
 *
 *   Licensed under the Apache License, Version 2.0 (the "License");
 *   you may not use this file except in compliance with the License.
@@ -16,10 +17,16 @@
 *   limitations under the License.
 *
 *   Created by Tony Stone on 6/4/15.
+*
+*   MODIFIED 2015 BY Tony Stone. Modifications licensed under Apache License, Version 2.0.
+*
 */
 
 #import <Foundation/Foundation.h>
 #import "GFPointAbstract.h"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 /**
  * @class       GFMultiPoint
@@ -30,6 +37,8 @@
  * @date        6/14/15
  */
 @interface GFMultiPoint : GFPointAbstract
+
+#pragma clang diagnostic pop
 
     /**
     * Initialize this geometry with the given WKT (Well-Known-Text) string.

--- a/GeoFeatures/GFMultiPolygon.h
+++ b/GeoFeatures/GFMultiPolygon.h
@@ -2,6 +2,7 @@
 *   GFMultiPolygon.h
 *
 *   Copyright 2015 The Climate Corporation
+*   Copyright 2015 Tony Stone
 *
 *   Licensed under the Apache License, Version 2.0 (the "License");
 *   you may not use this file except in compliance with the License.
@@ -16,10 +17,17 @@
 *   limitations under the License.
 *
 *   Created by Tony Stone on 6/4/15.
+*
+*   MODIFIED 2015 BY Tony Stone. Modifications licensed under Apache License, Version 2.0.
+*
 */
 
 #import <Foundation/Foundation.h>
+#import "GFPolygon.h"
 #import "GFPolygonAbstract.h"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 /**
  * @class       GFMultiPolygon
@@ -30,6 +38,8 @@
  * @date        6/14/15
  */
 @interface GFMultiPolygon : GFPolygonAbstract
+
+#pragma clang diagnostic pop
 
     /**
     * Initialize this geometry with the given WKT (Well-Known-Text) string.

--- a/GeoFeatures/GFPoint.h
+++ b/GeoFeatures/GFPoint.h
@@ -25,6 +25,9 @@
 #import <Foundation/Foundation.h>
 #import "GFPointAbstract.h"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 /**
 * @class       GFPoint
 *
@@ -34,6 +37,8 @@
 * @date        6/14/15
 */
 @interface GFPoint : GFPointAbstract
+
+#pragma clang diagnostic pop
 
     /**
     * Initialize this GFPoint with the x,y coordinates

--- a/GeoFeatures/GFPointAbstract.h
+++ b/GeoFeatures/GFPointAbstract.h
@@ -2,6 +2,7 @@
 *   GFPointAbstract.h
 *
 *   Copyright 2015 The Climate Corporation
+*   Copyright 2015 Tony Stone
 *
 *   Licensed under the Apache License, Version 2.0 (the "License");
 *   you may not use this file except in compliance with the License.
@@ -16,23 +17,29 @@
 *   limitations under the License.
 *
 *   Created by Tony Stone on 6/6/15.
+*
+*   MODIFIED 2015 BY Tony Stone. Modifications licensed under Apache License, Version 2.0.
+*
 */
 
 #import <Foundation/Foundation.h>
 #import "GFGeometry.h"
 
 /**
- * @class       GFPointAbstract
- *
- * @brief       An Abstract Point implementation.
- *
- * An Abstract Point implementation which should not
- * be instantiated on it's own.
- *
- * @warning Do not instantiate this abstract class.
- *
- * @author      Tony Stone
- * @date        6/6/15
- */
+* @class       GFPointAbstract
+*
+* @brief       An Abstract Point implementation.
+*
+* An Abstract Point implementation which should not
+* be instantiated on it's own.
+*
+* @warning Do not instantiate this abstract class.
+*
+* @deprecated This class will be removed in v2, please don't directly rely on it at this point.
+*
+* @author      Tony Stone
+* @date        6/6/15
+*/
+__deprecated_msg("This class will be removed in v2, please don't directly rely on it at this point.")
 @interface GFPointAbstract : GFGeometry
 @end

--- a/GeoFeatures/GFPointAbstract.mm
+++ b/GeoFeatures/GFPointAbstract.mm
@@ -30,7 +30,12 @@
 
 namespace gf = geofeatures::internal;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 @implementation GFPointAbstract (Protected)
+
+#pragma clang diagnostic pop
 
     - (id) init {
         NSAssert(![[self class] isMemberOfClass: [GFPointAbstract class]], @"Abstract class %@ can not be instantiated.  Please use one of the subclasses instead.", NSStringFromClass([self class]));

--- a/GeoFeatures/GFPolygon.h
+++ b/GeoFeatures/GFPolygon.h
@@ -2,6 +2,7 @@
 *   GFPolygon.h
 *
 *   Copyright 2015 The Climate Corporation
+*   Copyright 2015 Tony Stone
 *
 *   Licensed under the Apache License, Version 2.0 (the "License");
 *   you may not use this file except in compliance with the License.
@@ -16,10 +17,16 @@
 *   limitations under the License.
 *
 *   Created by Tony Stone on 6/3/15.
+*
+*   MODIFIED 2015 BY Tony Stone. Modifications licensed under Apache License, Version 2.0.
+*
 */
 
 #import <Foundation/Foundation.h>
 #import "GFPolygonAbstract.h"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
 /**
  * @class       GFPolygon
@@ -30,6 +37,8 @@
  * @date        6/6/15
  */
 @interface GFPolygon : GFPolygonAbstract
+
+#pragma clang diagnostic pop
 
     /**
     * Initialize this geometry with the given WKT (Well-Known-Text) string.

--- a/GeoFeatures/GFPolygonAbstract.h
+++ b/GeoFeatures/GFPolygonAbstract.h
@@ -2,6 +2,7 @@
 *   GFPolygonAbstract.h
 *
 *   Copyright 2015 The Climate Corporation
+*   Copyright 2015 Tony Stone
 *
 *   Licensed under the Apache License, Version 2.0 (the "License");
 *   you may not use this file except in compliance with the License.
@@ -16,23 +17,29 @@
 *   limitations under the License.
 *
 *   Created by Tony Stone on 6/6/15.
+*
+*   MODIFIED 2015 BY Tony Stone. Modifications licensed under Apache License, Version 2.0.
+*
 */
 
 #import <Foundation/Foundation.h>
 #import "GFGeometry.h"
 
 /**
- * @class       GFPolygonAbstract 
- *
- * @brief       An Abstract Polygon implementation.
- *
- * An Abstract Polygon implementation which should not
- * be instantiated on it's own.
- *
- * @warning Do not instantiate this abstract class.
- *
- * @author      Tony Stone
- * @date        6/6/15
- */
+* @class       GFPolygonAbstract
+*
+* @brief       An Abstract Polygon implementation.
+*
+* An Abstract Polygon implementation which should not
+* be instantiated on it's own.
+*
+* @warning Do not instantiate this abstract class.
+*
+* @deprecated This class will be removed in v2, please don't directly rely on it at this point.
+*
+* @author      Tony Stone
+* @date        6/6/15
+*/
+__deprecated_msg("This class will be removed in v2, please don't directly rely on it at this point.")
 @interface GFPolygonAbstract : GFGeometry
 @end

--- a/GeoFeatures/GFPolygonAbstract.mm
+++ b/GeoFeatures/GFPolygonAbstract.mm
@@ -36,12 +36,17 @@
 
 namespace gf = geofeatures::internal;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 @implementation GFPolygonAbstract (Protected)
 
     - (id) init {
         NSAssert(![[self class] isMemberOfClass: [GFPolygonAbstract class]], @"Abstract class %@ can not be instantiated.  Please use one of the subclasses instead.", NSStringFromClass([self class]));
         return nil;
     }
+
+#pragma clang diagnostic pop
 
     - (gf::Polygon)cppPolygonWithGeoJSONCoordinates:(NSArray *)coordinates {
 


### PR DESCRIPTION
- Deprecating GFPointAbstract.  This class will be unneeded and removed in v2.
- Deprecating GFLineStringAbstract. This class will be unneeded and removed in v2.
- Deprecating GFPolygonAbstract. This class will be unneeded and removed in v2.
