### PR TITLE
Refactoring geometryVariant access

### DIFF
--- a/GeoFeatures/GFBox.mm
+++ b/GeoFeatures/GFBox.mm
@@ -47,8 +47,13 @@ namespace gf = geofeatures::internal;
 
     - (id)initWithMinCorner:(GFPoint *) minCorner maxCorner:(GFPoint *) maxCorner {
         try {
-            gf::Box box(boost::polymorphic_strict_get<gf::Point>([minCorner cppGeometryReference]),
-                                 boost::polymorphic_strict_get<gf::Point>([maxCorner cppGeometryReference]));
+            gf::Box box;
+
+            box.minCorner().set<0>([minCorner x]);
+            box.minCorner().set<1>([minCorner y]);
+
+            box.maxCorner().set<0>([minCorner x]);
+            box.maxCorner().set<1>([minCorner y]);
 
             return [super initWithCPPGeometryVariant: box];
 
@@ -103,21 +108,18 @@ namespace gf = geofeatures::internal;
     }
 
     - (GFPoint *) minCorner {
-        const gf::Box & box = boost::polymorphic_strict_get<gf::Box>([self cppGeometryConstReference]);
-
-        return [[GFPoint alloc] initWithCPPGeometryVariant: box.minCorner()];
+        return [[GFPoint alloc] initWithCPPGeometryVariant: gf::strict_get <gf::Box>(_intd).minCorner()];
     }
 
     - (GFPoint *) maxCorner {
-        const gf::Box & box = boost::polymorphic_strict_get<gf::Box>([self cppGeometryConstReference]);
 
-        return [[GFPoint alloc] initWithCPPGeometryVariant: box.maxCorner()];
+        return [[GFPoint alloc] initWithCPPGeometryVariant: gf::strict_get <gf::Box>(_intd).maxCorner()];
     }
 
     - (NSDictionary *)toGeoJSONGeometry {
 
         try {
-            const gf::Box & box = boost::polymorphic_strict_get<gf::Box>([self cppGeometryConstReference]);
+            const gf::Box & box = gf::strict_get <gf::Box>(_intd);
 
             double minCornerX = box.minCorner().get<0>();
             double minCornerY = box.minCorner().get<1>();
@@ -132,7 +134,7 @@ namespace gf = geofeatures::internal;
     }
 
     - (NSArray *)mkMapOverlays {
-        const gf::Box & box = boost::polymorphic_strict_get<gf::Box>([self cppGeometryConstReference]);
+        const gf::Box & box = gf::strict_get <gf::Box>(_intd);
 
         CLLocationCoordinate2D coordinates[5];
 

--- a/GeoFeatures/GFGeometry.h
+++ b/GeoFeatures/GFGeometry.h
@@ -27,6 +27,8 @@
 @class GFPoint;
 @class GFBox;
 
+struct GFInternal;
+
 /**
  * @class       GFGeometry
  *
@@ -40,7 +42,9 @@
  * @author      Tony Stone
  * @date        6/14/15
  */
-@interface GFGeometry : NSObject <NSCoding, NSCopying>
+@interface GFGeometry : NSObject <NSCoding, NSCopying> {
+        struct GFInternal * _intd;
+    }
 
     /** Checks if a geometry is valid.
     */

--- a/GeoFeatures/GFGeometryCollection.mm
+++ b/GeoFeatures/GFGeometryCollection.mm
@@ -129,7 +129,7 @@ namespace geofeatures {
                 if (![geometry isKindOfClass: [GFGeometry class]]) {
                     @throw [NSException exceptionWithName: NSInvalidArgumentException reason:[NSString stringWithFormat: @"Invalid class in array for initialization of %@.  All array elements must be a GFGeometry or subclass of GFGeometry.", NSStringFromClass([self class])] userInfo: nil];
                 }
-                boost::apply_visitor(gf::detail::AddGeometry(geometryCollection), [geometry cppGeometryReference]);
+                boost::apply_visitor(gf::detail::AddGeometry(geometryCollection), geometry->_intd->geometryVariant);
             }
             return geometryCollection;
 
@@ -141,7 +141,7 @@ namespace geofeatures {
     - (GFGeometry *)geometryAtIndex:(NSUInteger)index {
 
         try {
-            const gf::GeometryCollection & geometry = boost::polymorphic_strict_get<gf::GeometryCollection>([self cppGeometryConstReference]);
+            const gf::GeometryCollection & geometry = gf::strict_get<gf::GeometryCollection>(_intd);
 
             if (index >= geometry.size()) {
                 @throw [NSException exceptionWithName: NSRangeException reason: @"Index out of range." userInfo: nil];
@@ -157,7 +157,7 @@ namespace geofeatures {
 
     - (GFGeometry *)firstGeometry {
         try {
-            const gf::GeometryCollection & geometry = boost::polymorphic_strict_get<gf::GeometryCollection>([self cppGeometryConstReference]);
+            const gf::GeometryCollection & geometry = gf::strict_get<gf::GeometryCollection>(_intd);
 
             if (geometry.size() > 0) {
 
@@ -172,7 +172,7 @@ namespace geofeatures {
     - (GFGeometry *)lastGeometry {
 
         try {
-            const gf::GeometryCollection & geometry = boost::polymorphic_strict_get<gf::GeometryCollection>([self cppGeometryConstReference]);
+            const gf::GeometryCollection & geometry = gf::strict_get<gf::GeometryCollection>(_intd);
 
             if (geometry.size() > 0) {
 
@@ -188,7 +188,7 @@ namespace geofeatures {
     - (NSUInteger)count {
 
         try {
-            const gf::GeometryCollection & geometry = boost::polymorphic_strict_get<gf::GeometryCollection>([self cppGeometryConstReference]);
+            const gf::GeometryCollection & geometry = gf::strict_get<gf::GeometryCollection>(_intd);
 
             return geometry.size();
 

--- a/GeoFeatures/GFLineString.mm
+++ b/GeoFeatures/GFLineString.mm
@@ -64,9 +64,8 @@ namespace gf = geofeatures::internal;
 
     - (NSDictionary *) toGeoJSONGeometry {
         try {
-            const gf::LineString & lineString = boost::polymorphic_strict_get<gf::LineString>([self cppGeometryConstReference]);
-            
-            return @{@"type": @"Point", @"coordinates": [self geoJSONCoordinatesWithCPPLineString: lineString]};
+
+            return @{@"type": @"Point", @"coordinates": [self geoJSONCoordinatesWithCPPLineString: gf::strict_get<gf::LineString>(_intd)]};
             
         } catch (std::exception & e) {
             @throw [NSException exceptionWithName:@"Exception" reason: [NSString stringWithUTF8String: e.what()] userInfo:nil];
@@ -75,9 +74,8 @@ namespace gf = geofeatures::internal;
 
     - (NSArray *)mkMapOverlays {
         try {
-            const gf::LineString & lineString = boost::polymorphic_strict_get<gf::LineString>([self cppGeometryConstReference]);
-            
-            return @[[self mkOverlayWithCPPLineString: lineString]];
+
+            return @[[self mkOverlayWithCPPLineString: gf::strict_get<gf::LineString>(_intd)]];
             
         } catch (std::exception & e) {
             @throw [NSException exceptionWithName:@"Exception" reason: [NSString stringWithUTF8String: e.what()] userInfo:nil];

--- a/GeoFeatures/GFLineStringAbstract.mm
+++ b/GeoFeatures/GFLineStringAbstract.mm
@@ -41,12 +41,12 @@ namespace gf = geofeatures::internal;
 
 @implementation GFLineStringAbstract (Protected)
 
-#pragma clang diagnostic pop
-
     - (id) init {
         NSAssert(![[self class] isMemberOfClass: [GFLineStringAbstract class]], @"Abstract class %@ can not be instantiated.  Please use one of the subclasses instead.", NSStringFromClass([self class]));
         return nil;
     }
+
+#pragma clang diagnostic pop
 
     - (gf::LineString)cppLineStringWithGeoJSONCoordinates:(NSArray *)coordinates {
 

--- a/GeoFeatures/GFMultiLineString.mm
+++ b/GeoFeatures/GFMultiLineString.mm
@@ -74,9 +74,15 @@ namespace gf = geofeatures::internal;
         //
         gf::MultiLineString multiLineString;
 
-        for (NSArray *lineString in coordinates) {
-            multiLineString.push_back([self cppLineStringWithGeoJSONCoordinates:lineString]);
+        try {
+            for (NSArray * lineString in coordinates) {
+                multiLineString.push_back([self cppLineStringWithGeoJSONCoordinates: lineString]);
+            }
+
+        } catch (std::exception & e) {
+            @throw [NSException exceptionWithName:@"Exception" reason: [NSString stringWithUTF8String: e.what()] userInfo:nil];
         }
+
         return [super initWithCPPGeometryVariant: multiLineString];
     }
 
@@ -84,7 +90,7 @@ namespace gf = geofeatures::internal;
         NSMutableArray * lineStrings = [[NSMutableArray alloc] init];
 
         try {
-            const gf::MultiLineString & multiLineString = boost::polymorphic_strict_get<gf::MultiLineString>([self cppGeometryConstReference]);
+            const gf::MultiLineString & multiLineString = gf::strict_get<gf::MultiLineString>(_intd);
 
             for (gf::MultiLineString::vector::const_iterator it = multiLineString.begin();  it != multiLineString.end(); ++it ) {
                 [lineStrings addObject:[self geoJSONCoordinatesWithCPPLineString: (*it)]];
@@ -99,7 +105,7 @@ namespace gf = geofeatures::internal;
         NSMutableArray * mkPolygons = [[NSMutableArray alloc] init];
 
         try {
-            const gf::MultiLineString & multiLineString = boost::polymorphic_strict_get<gf::MultiLineString>([self cppGeometryConstReference]);
+            const gf::MultiLineString & multiLineString = gf::strict_get<gf::MultiLineString>(_intd);
 
             for (gf::MultiLineString::vector::const_iterator it = multiLineString.begin();  it != multiLineString.end(); ++it ) {
                 [mkPolygons addObject:[self mkOverlayWithCPPLineString: (*it)]];

--- a/GeoFeatures/GFMultiPoint.mm
+++ b/GeoFeatures/GFMultiPoint.mm
@@ -68,9 +68,15 @@ namespace gf = geofeatures::internal;
         //
         gf::MultiPoint multiPoint;
 
-        for (NSArray * coordinate in coordinates) {
-            multiPoint.push_back([self cppPointWithGeoJSONCoordinates: coordinate]);
+        try {
+            for (NSArray * coordinate in coordinates) {
+                multiPoint.push_back([self cppPointWithGeoJSONCoordinates: coordinate]);
+            }
+
+        } catch (std::exception & e) {
+            @throw [NSException exceptionWithName:@"Exception" reason: [NSString stringWithUTF8String: e.what()] userInfo:nil];
         }
+
         return [super initWithCPPGeometryVariant: multiPoint];
     }
 
@@ -78,7 +84,7 @@ namespace gf = geofeatures::internal;
         NSMutableArray * polygons = [[NSMutableArray alloc] init];
 
         try {
-            const gf::MultiPoint & multiPoint = boost::polymorphic_strict_get<gf::MultiPoint>([self cppGeometryConstReference]);
+            const gf::MultiPoint & multiPoint = gf::strict_get<gf::MultiPoint>(_intd);
 
             for (gf::MultiPoint::vector::const_iterator it = multiPoint.begin();  it != multiPoint.end(); ++it ) {
                 [polygons addObject: [self geoJSONCoordinatesWithCPPPoint: (*it)]];
@@ -93,7 +99,7 @@ namespace gf = geofeatures::internal;
         NSMutableArray * mkPolygons = [[NSMutableArray alloc] init];
 
         try {
-            const gf::MultiPoint & multiPoint = boost::polymorphic_strict_get<gf::MultiPoint>([self cppGeometryConstReference]);
+            const gf::MultiPoint & multiPoint = gf::strict_get<gf::MultiPoint>(_intd);
 
             for (gf::MultiPoint::vector::const_iterator it = multiPoint.vector::begin();  it != multiPoint.vector::end(); ++it ) {
                 [mkPolygons addObject: [self mkOverlayWithCPPPoint: (*it)]];

--- a/GeoFeatures/GFMultiPolygon.mm
+++ b/GeoFeatures/GFMultiPolygon.mm
@@ -81,8 +81,13 @@ namespace gf = geofeatures::internal;
         //
         gf::MultiPolygon multiPolygon;
 
-        for (NSArray * polygon in coordinates) {
-            multiPolygon.push_back([self cppPolygonWithGeoJSONCoordinates: polygon]);
+        try {
+            for (NSArray * polygon in coordinates) {
+                multiPolygon.push_back([self cppPolygonWithGeoJSONCoordinates: polygon]);
+            }
+
+        } catch (std::exception & e) {
+            @throw [NSException exceptionWithName:@"Exception" reason: [NSString stringWithUTF8String: e.what()] userInfo:nil];
         }
         return [super initWithCPPGeometryVariant: multiPolygon];
     }
@@ -91,7 +96,7 @@ namespace gf = geofeatures::internal;
         NSMutableArray * polygons = [[NSMutableArray alloc] init];
 
         try {
-            const gf::MultiPolygon & multiPolygon = boost::polymorphic_strict_get<gf::MultiPolygon>([self cppGeometryConstReference]);
+            const gf::MultiPolygon & multiPolygon = gf::strict_get<gf::MultiPolygon>(_intd);
 
             for (gf::MultiPolygon::vector::const_iterator it = multiPolygon.begin();  it != multiPolygon.end(); ++it ) {
                 [polygons addObject: [self geoJSONCoordinatesWithCPPPolygon: (*it)]];
@@ -106,7 +111,7 @@ namespace gf = geofeatures::internal;
         NSMutableArray * mkPolygons = [[NSMutableArray alloc] init];
         
         try {
-            const gf::MultiPolygon & multiPolygon = boost::polymorphic_strict_get<gf::MultiPolygon>([self cppGeometryConstReference]);
+            const gf::MultiPolygon & multiPolygon = gf::strict_get<gf::MultiPolygon>(_intd);
 
             for (gf::MultiPolygon::vector::const_iterator it = multiPolygon.begin();  it != multiPolygon.end(); ++it ) {
                 [mkPolygons addObject:[self mkOverlayWithCPPPolygon: (*it)]];

--- a/GeoFeatures/GFPoint.mm
+++ b/GeoFeatures/GFPoint.mm
@@ -88,27 +88,25 @@ namespace gf = geofeatures::internal;
     }
 
     - (double) x {
-        const gf::Point & point = boost::polymorphic_strict_get<gf::Point>([self cppGeometryConstReference]);
+        const gf::Point & point = gf::strict_get<gf::Point>(_intd);
 
         return point.get<0>();
     }
 
     - (double) y {
-        const gf::Point & point = boost::polymorphic_strict_get<gf::Point>([self cppGeometryConstReference]);
+        const gf::Point & point = gf::strict_get<gf::Point>(_intd);
 
         return point.get<1>();
     }
 
     - (NSDictionary *)toGeoJSONGeometry {
-        const gf::Point & point = boost::polymorphic_strict_get<gf::Point>([self cppGeometryConstReference]);
 
-        return @{@"type": @"Point", @"coordinates": [self geoJSONCoordinatesWithCPPPoint: point]};
+        return @{@"type": @"Point", @"coordinates": [self geoJSONCoordinatesWithCPPPoint: gf::strict_get<gf::Point>(_intd)]};
     }
 
     - (NSArray *)mkMapOverlays {
-        const gf::Point & point = boost::polymorphic_strict_get<gf::Point>([self cppGeometryConstReference]);
 
-        return @[[self mkOverlayWithCPPPoint: point]];
+        return @[[self mkOverlayWithCPPPoint: gf::strict_get<gf::Point>(_intd)]];
     }
 
 @end

--- a/GeoFeatures/GFPointAbstract.mm
+++ b/GeoFeatures/GFPointAbstract.mm
@@ -35,12 +35,12 @@ namespace gf = geofeatures::internal;
 
 @implementation GFPointAbstract (Protected)
 
-#pragma clang diagnostic pop
-
     - (id) init {
         NSAssert(![[self class] isMemberOfClass: [GFPointAbstract class]], @"Abstract class %@ can not be instantiated.  Please use one of the subclasses instead.", NSStringFromClass([self class]));
         return nil;
     }
+
+#pragma clang diagnostic pop
 
     - (gf::Point)cppPointWithGeoJSONCoordinates:(NSArray *)coordinates {
 

--- a/GeoFeatures/GFPolygon.mm
+++ b/GeoFeatures/GFPolygon.mm
@@ -72,11 +72,11 @@ namespace gf = geofeatures::internal;
     }
 
     - (NSDictionary *)toGeoJSONGeometry {
-        return @{@"type": @"Polygon", @"coordinates": [self geoJSONCoordinatesWithCPPPolygon: boost::polymorphic_strict_get<gf::Polygon>([self cppGeometryConstReference])]};
+        return @{@"type": @"Polygon", @"coordinates": [self geoJSONCoordinatesWithCPPPolygon: gf::strict_get<gf::Polygon>(_intd)]};
     }
 
     - (NSArray *)mkMapOverlays {
-        return @[[self mkOverlayWithCPPPolygon: boost::polymorphic_strict_get<gf::Polygon>([self cppGeometryConstReference])]];
+        return @[[self mkOverlayWithCPPPolygon: gf::strict_get<gf::Polygon>(_intd)]];
     }
 
 @end

--- a/GeoFeatures/Internal/detail/GFGeometry+Protected.hpp
+++ b/GeoFeatures/Internal/detail/GFGeometry+Protected.hpp
@@ -34,11 +34,26 @@
 
     - (id) initWithCPPGeometryVariant: (geofeatures::internal::GeometryVariant) geometryVariant;
 
-    - (const geofeatures::internal::GeometryVariant &)cppGeometryConstReference;
-    - (geofeatures::internal::GeometryVariant &)cppGeometryReference;
-
     - (id)initWithWKT:(NSString *)wkt;
 
 @end
+
+struct GFInternal {
+    geofeatures::internal::GeometryVariant geometryVariant;
+
+    GFInternal(geofeatures::internal::GeometryVariant aGeometryVariant) : geometryVariant(aGeometryVariant) {};
+};
+
+namespace geofeatures {
+    namespace internal {
+
+        template <typename T>
+        inline T & strict_get(GFInternal * internal)  {
+            return boost::polymorphic_strict_get<T>(internal->geometryVariant);
+        }
+    }
+}
+
+
 
 #endif // __GFGeometryProtected_hpp


### PR DESCRIPTION
- Added GFInternal struct.
- Embedded geometryVariant in a new GFInternal struct pointer that is visible by all subclasses.
- Added geofeatures::internal::strict_get method to access GFInternal's geometryVariant using boost::polymorphic_strict_get.
- Removed protected methods to access the geometryVariant reference.
- Modified all subclasses of GFGeometry to use direct access to the new GFInternal.
