### PR TITLE
Refactoring

### DIFF
--- a/GeoFeatures/GFBox.mm
+++ b/GeoFeatures/GFBox.mm
@@ -113,18 +113,18 @@ namespace gf = geofeatures::internal;
     }
 
     - (GFPoint *) minCorner {
-        return [[GFPoint alloc] initWithCPPGeometryVariant: gf::strict_get <gf::Box>(_intd).minCorner()];
+        return [[GFPoint alloc] initWithCPPGeometryVariant: boost::polymorphic_strict_get<gf::Box>(_members->geometryVariant).minCorner()];
     }
 
     - (GFPoint *) maxCorner {
 
-        return [[GFPoint alloc] initWithCPPGeometryVariant: gf::strict_get <gf::Box>(_intd).maxCorner()];
+        return [[GFPoint alloc] initWithCPPGeometryVariant: boost::polymorphic_strict_get<gf::Box>(_members->geometryVariant).maxCorner()];
     }
 
     - (NSDictionary *)toGeoJSONGeometry {
 
         try {
-            const gf::Box & box = gf::strict_get <gf::Box>(_intd);
+            const gf::Box & box = boost::polymorphic_strict_get<gf::Box>(_members->geometryVariant);
 
             double minCornerX = box.minCorner().get<0>();
             double minCornerY = box.minCorner().get<1>();
@@ -139,7 +139,7 @@ namespace gf = geofeatures::internal;
     }
 
     - (NSArray *)mkMapOverlays {
-        const gf::Box & box = gf::strict_get <gf::Box>(_intd);
+        const gf::Box & box = boost::polymorphic_strict_get<gf::Box>(_members->geometryVariant);
 
         CLLocationCoordinate2D coordinates[5];
 

--- a/GeoFeatures/GFGeometry.h
+++ b/GeoFeatures/GFGeometry.h
@@ -27,7 +27,7 @@
 @class GFPoint;
 @class GFBox;
 
-struct GFInternal;
+struct GFMembers;
 
 /**
  * @class       GFGeometry
@@ -43,7 +43,7 @@ struct GFInternal;
  * @date        6/14/15
  */
 @interface GFGeometry : NSObject <NSCoding, NSCopying> {
-        struct GFInternal * _intd;
+        struct GFMembers * _members;
     }
 
     /** Checks if a geometry is valid.

--- a/GeoFeatures/GFGeometryCollection.mm
+++ b/GeoFeatures/GFGeometryCollection.mm
@@ -127,7 +127,7 @@ namespace geofeatures {
                 if (![geometry isKindOfClass: [GFGeometry class]]) {
                     @throw [NSException exceptionWithName: NSInvalidArgumentException reason:[NSString stringWithFormat: @"Invalid class in array for initialization of %@.  All array elements must be a GFGeometry or subclass of GFGeometry.", NSStringFromClass([self class])] userInfo: nil];
                 }
-                boost::apply_visitor(gf::detail::AddGeometry(geometryCollection), geometry->_intd->geometryVariant);
+                boost::apply_visitor(gf::detail::AddGeometry(geometryCollection), geometry->_members->geometryVariant);
             }
             return geometryCollection;
 
@@ -139,7 +139,7 @@ namespace geofeatures {
     - (GFGeometry *)geometryAtIndex:(NSUInteger)index {
 
         try {
-            const gf::GeometryCollection & geometry = gf::strict_get<gf::GeometryCollection>(_intd);
+            auto& geometry = boost::polymorphic_strict_get<gf::GeometryCollection>(_members->geometryVariant);
 
             if (index >= geometry.size()) {
                 @throw [NSException exceptionWithName: NSRangeException reason: @"Index out of range." userInfo: nil];
@@ -155,7 +155,7 @@ namespace geofeatures {
 
     - (GFGeometry *)firstGeometry {
         try {
-            const gf::GeometryCollection & geometry = gf::strict_get<gf::GeometryCollection>(_intd);
+            auto& geometry = boost::polymorphic_strict_get<gf::GeometryCollection>(_members->geometryVariant);
 
             if (geometry.size() > 0) {
 
@@ -170,7 +170,7 @@ namespace geofeatures {
     - (GFGeometry *)lastGeometry {
 
         try {
-            const gf::GeometryCollection & geometry = gf::strict_get<gf::GeometryCollection>(_intd);
+            auto& geometry = boost::polymorphic_strict_get<gf::GeometryCollection>(_members->geometryVariant);
 
             if (geometry.size() > 0) {
 
@@ -186,7 +186,7 @@ namespace geofeatures {
     - (NSUInteger)count {
 
         try {
-            const gf::GeometryCollection & geometry = gf::strict_get<gf::GeometryCollection>(_intd);
+            auto& geometry = boost::polymorphic_strict_get<gf::GeometryCollection>(_members->geometryVariant);
 
             return geometry.size();
 

--- a/GeoFeatures/GFLineString.mm
+++ b/GeoFeatures/GFLineString.mm
@@ -70,7 +70,7 @@ namespace gf = geofeatures::internal;
     - (NSDictionary *) toGeoJSONGeometry {
         try {
 
-            return @{@"type": @"Point", @"coordinates": [self geoJSONCoordinatesWithCPPLineString: gf::strict_get<gf::LineString>(_intd)]};
+            return @{@"type": @"Point", @"coordinates": [self geoJSONCoordinatesWithCPPLineString: boost::polymorphic_strict_get<gf::LineString>(_members->geometryVariant)]};
             
         } catch (std::exception & e) {
             @throw [NSException exceptionWithName:@"Exception" reason: [NSString stringWithUTF8String: e.what()] userInfo:nil];
@@ -80,7 +80,7 @@ namespace gf = geofeatures::internal;
     - (NSArray *)mkMapOverlays {
         try {
 
-            return @[[self mkOverlayWithCPPLineString: gf::strict_get<gf::LineString>(_intd)]];
+            return @[[self mkOverlayWithCPPLineString: boost::polymorphic_strict_get<gf::LineString>(_members->geometryVariant)]];
             
         } catch (std::exception & e) {
             @throw [NSException exceptionWithName:@"Exception" reason: [NSString stringWithUTF8String: e.what()] userInfo:nil];

--- a/GeoFeatures/GFMultiLineString.mm
+++ b/GeoFeatures/GFMultiLineString.mm
@@ -95,7 +95,7 @@ namespace gf = geofeatures::internal;
         NSMutableArray * lineStrings = [[NSMutableArray alloc] init];
 
         try {
-            const gf::MultiLineString & multiLineString = gf::strict_get<gf::MultiLineString>(_intd);
+            auto& multiLineString = boost::polymorphic_strict_get<gf::MultiLineString>(_members->geometryVariant);
 
             for (gf::MultiLineString::vector::const_iterator it = multiLineString.begin();  it != multiLineString.end(); ++it ) {
                 [lineStrings addObject:[self geoJSONCoordinatesWithCPPLineString: (*it)]];
@@ -110,7 +110,7 @@ namespace gf = geofeatures::internal;
         NSMutableArray * mkPolygons = [[NSMutableArray alloc] init];
 
         try {
-            const gf::MultiLineString & multiLineString = gf::strict_get<gf::MultiLineString>(_intd);
+            auto& multiLineString = boost::polymorphic_strict_get<gf::MultiLineString>(_members->geometryVariant);
 
             for (gf::MultiLineString::vector::const_iterator it = multiLineString.begin();  it != multiLineString.end(); ++it ) {
                 [mkPolygons addObject:[self mkOverlayWithCPPLineString: (*it)]];

--- a/GeoFeatures/GFMultiPoint.mm
+++ b/GeoFeatures/GFMultiPoint.mm
@@ -89,7 +89,7 @@ namespace gf = geofeatures::internal;
         NSMutableArray * polygons = [[NSMutableArray alloc] init];
 
         try {
-            const gf::MultiPoint & multiPoint = gf::strict_get<gf::MultiPoint>(_intd);
+            auto& multiPoint = boost::polymorphic_strict_get<gf::MultiPoint>(_members->geometryVariant);
 
             for (gf::MultiPoint::vector::const_iterator it = multiPoint.begin();  it != multiPoint.end(); ++it ) {
                 [polygons addObject: [self geoJSONCoordinatesWithCPPPoint: (*it)]];
@@ -104,7 +104,7 @@ namespace gf = geofeatures::internal;
         NSMutableArray * mkPolygons = [[NSMutableArray alloc] init];
 
         try {
-            const gf::MultiPoint & multiPoint = gf::strict_get<gf::MultiPoint>(_intd);
+            auto& multiPoint = boost::polymorphic_strict_get<gf::MultiPoint>(_members->geometryVariant);
 
             for (gf::MultiPoint::vector::const_iterator it = multiPoint.vector::begin();  it != multiPoint.vector::end(); ++it ) {
                 [mkPolygons addObject: [self mkOverlayWithCPPPoint: (*it)]];

--- a/GeoFeatures/GFMultiPolygon.mm
+++ b/GeoFeatures/GFMultiPolygon.mm
@@ -101,7 +101,7 @@ namespace gf = geofeatures::internal;
         NSMutableArray * polygons = [[NSMutableArray alloc] init];
 
         try {
-            const gf::MultiPolygon & multiPolygon = gf::strict_get<gf::MultiPolygon>(_intd);
+            auto& multiPolygon = boost::polymorphic_strict_get<gf::MultiPolygon>(_members->geometryVariant);
 
             for (gf::MultiPolygon::vector::const_iterator it = multiPolygon.begin();  it != multiPolygon.end(); ++it ) {
                 [polygons addObject: [self geoJSONCoordinatesWithCPPPolygon: (*it)]];
@@ -116,7 +116,7 @@ namespace gf = geofeatures::internal;
         NSMutableArray * mkPolygons = [[NSMutableArray alloc] init];
         
         try {
-            const gf::MultiPolygon & multiPolygon = gf::strict_get<gf::MultiPolygon>(_intd);
+            auto& multiPolygon = boost::polymorphic_strict_get<gf::MultiPolygon>(_members->geometryVariant);
 
             for (gf::MultiPolygon::vector::const_iterator it = multiPolygon.begin();  it != multiPolygon.end(); ++it ) {
                 [mkPolygons addObject:[self mkOverlayWithCPPPolygon: (*it)]];

--- a/GeoFeatures/GFPoint.mm
+++ b/GeoFeatures/GFPoint.mm
@@ -93,25 +93,25 @@ namespace gf = geofeatures::internal;
     }
 
     - (double) x {
-        const gf::Point & point = gf::strict_get<gf::Point>(_intd);
+        auto& point = boost::polymorphic_strict_get<gf::Point>(_members->geometryVariant);
 
         return point.get<0>();
     }
 
     - (double) y {
-        const gf::Point & point = gf::strict_get<gf::Point>(_intd);
+        auto& point = boost::polymorphic_strict_get<gf::Point>(_members->geometryVariant);
 
         return point.get<1>();
     }
 
     - (NSDictionary *)toGeoJSONGeometry {
 
-        return @{@"type": @"Point", @"coordinates": [self geoJSONCoordinatesWithCPPPoint: gf::strict_get<gf::Point>(_intd)]};
+        return @{@"type": @"Point", @"coordinates": [self geoJSONCoordinatesWithCPPPoint: boost::polymorphic_strict_get<gf::Point>(_members->geometryVariant)]};
     }
 
     - (NSArray *)mkMapOverlays {
 
-        return @[[self mkOverlayWithCPPPoint: gf::strict_get<gf::Point>(_intd)]];
+        return @[[self mkOverlayWithCPPPoint: boost::polymorphic_strict_get<gf::Point>(_members->geometryVariant)]];
     }
 
 @end

--- a/GeoFeatures/GFPolygon.mm
+++ b/GeoFeatures/GFPolygon.mm
@@ -77,11 +77,11 @@ namespace gf = geofeatures::internal;
     }
 
     - (NSDictionary *)toGeoJSONGeometry {
-        return @{@"type": @"Polygon", @"coordinates": [self geoJSONCoordinatesWithCPPPolygon: gf::strict_get<gf::Polygon>(_intd)]};
+        return @{@"type": @"Polygon", @"coordinates": [self geoJSONCoordinatesWithCPPPolygon: boost::polymorphic_strict_get<gf::Polygon>(_members->geometryVariant)]};
     }
 
     - (NSArray *)mkMapOverlays {
-        return @[[self mkOverlayWithCPPPolygon: gf::strict_get<gf::Polygon>(_intd)]];
+        return @[[self mkOverlayWithCPPPolygon: boost::polymorphic_strict_get<gf::Polygon>(_members->geometryVariant)]];
     }
 
 @end

--- a/GeoFeatures/Internal/detail/GFGeometry+Protected.hpp
+++ b/GeoFeatures/Internal/detail/GFGeometry+Protected.hpp
@@ -27,8 +27,18 @@
 
 #import <Foundation/Foundation.h>
 #import "GFGeometry.h"
+#import "GFPoint.h"
+#import "GFMultiPoint.h"
+#import "GFBox.h"
+#import "GFLineString.h"
+#import "GFMultiLineString.h"
+#import "GFPolygon.h"
+#import "GFMultiPolygon.h"
+#import "GFGeometryCollection.h"
 
+#include "geofeatures/internal/Geometry.hpp"
 #include "geofeatures/internal/GeometryVariant.hpp"
+
 
 @interface GFGeometry (Protected)
 
@@ -38,22 +48,56 @@
 
 @end
 
-struct GFInternal {
-    geofeatures::internal::GeometryVariant geometryVariant;
+/*
+ * @Note GFMembers structure is intentionally in the global namespace
+ */
+struct GFMembers {
+    public:
+        GFMembers(geofeatures::internal::GeometryVariant aGeometryVariant) : geometryVariant(aGeometryVariant) {};
 
-    GFInternal(geofeatures::internal::GeometryVariant aGeometryVariant) : geometryVariant(aGeometryVariant) {};
+        geofeatures::internal::GeometryVariant geometryVariant;
 };
 
 namespace geofeatures {
     namespace internal {
 
-        template <typename T>
-        inline T & strict_get(GFInternal * internal)  {
-            return boost::polymorphic_strict_get<T>(internal->geometryVariant);
-        }
+        /** static_visitor to transform the variant type to an ObjC type
+         *
+         */
+        class GFInstanceFromVariant : public  boost::static_visitor<GFGeometry *> {
+
+        public:
+            template <typename T>
+            GFGeometry * operator()(const T & v) const {
+                return nil;
+            }
+            GFGeometry * operator()(const Point & v) const {
+                return [[GFPoint alloc] initWithCPPGeometryVariant: v];;
+            }
+            GFGeometry * operator()(const MultiPoint & v) const {
+                return [[GFMultiPoint alloc] initWithCPPGeometryVariant: v];;
+            }
+            GFGeometry * operator()(const Box & v) const {
+                return [[GFBox alloc] initWithCPPGeometryVariant: v];;
+            }
+            GFGeometry * operator()(const LineString & v) const {
+                return [[GFLineString alloc] initWithCPPGeometryVariant: v];;
+            }
+            GFGeometry * operator()(const MultiLineString & v) const {
+                return [[GFMultiLineString alloc] initWithCPPGeometryVariant: v];;
+            }
+            GFGeometry * operator()(const Polygon & v) const {
+                return [[GFPolygon alloc] initWithCPPGeometryVariant: v];;
+            }
+            GFGeometry * operator()(const MultiPolygon & v) const {
+                return [[GFMultiPolygon alloc] initWithCPPGeometryVariant: v];;
+            }
+            GFGeometry * operator()(const GeometryCollection & v) const {
+                return [[GFGeometryCollection alloc] initWithCPPGeometryVariant: v];;
+            }
+        };
+
     }
 }
-
-
 
 #endif // __GFGeometryProtected_hpp


### PR DESCRIPTION
- Moving GFInstanceFromVariant to the protected GFGeometry+Protected.hpp header so it can be used in any class.
- Removing ::default namespace from GFInstanceFromVariant.
- Renamed GFInternal to GFMembers to make its intentions clear.
- Removing gfeofeatures::internal::strict_get because it was a bad idea to hide the intentions of getting a member from the members structure.  Now using boost::polymorphicc_strict_get<T>(_members-geoemtryVariant) directly which is much clearer as to what is going on.
- Changing all declarations of the variables on the left of the boost:polymorphic_strict_get to auto& to simplify the code.
