### PR TITLE
Refactor tests to register more coverage.

### DIFF
--- a/Example/Tests/Model/GFBoxTests.m
+++ b/Example/Tests/Model/GFBoxTests.m
@@ -37,8 +37,6 @@ static NSString * invalidGeometryJSONString = @"{ \"type\": \"%@\","
         "   }";
 
 @implementation GFBoxTests {
-        Class expectedClass;
-
         NSString * geoJSONGeometryName;
 
         GFBox * geometry1a;
@@ -49,7 +47,6 @@ static NSString * invalidGeometryJSONString = @"{ \"type\": \"%@\","
     - (void)setUp {
         [super setUp];
 
-        expectedClass       = NSClassFromString( @"GFBox");
         geoJSONGeometryName = @"Box";
         
         geometry1a = [[GFBox alloc] initWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
@@ -58,8 +55,6 @@ static NSString * invalidGeometryJSONString = @"{ \"type\": \"%@\","
     }
 
     - (void)tearDown {
-
-        expectedClass       = nil;
         geoJSONGeometryName = nil;
         
         geometry1a = nil;
@@ -73,8 +68,8 @@ static NSString * invalidGeometryJSONString = @"{ \"type\": \"%@\","
         XCTAssertNotNil(geometry1a);
         XCTAssertNotNil(geometry2);
 
-        XCTAssertEqual([geometry1a class], expectedClass);
-        XCTAssertEqual([geometry2 class], expectedClass);
+        XCTAssertEqual([geometry1a class], [GFBox class]);
+        XCTAssertEqual([geometry2 class], [GFBox class]);
     }
 
     - (void)testFailedConstruction {

--- a/Example/Tests/Model/GFBoxTests.m
+++ b/Example/Tests/Model/GFBoxTests.m
@@ -66,8 +66,8 @@ static __attribute__((constructor(101),used,visibility("internal"))) void static
         XCTAssertNotNil([[[GFBox alloc] initWithGeoJSONGeometry: geoJSON1] description]);
         XCTAssertNotNil([[[GFBox alloc] initWithGeoJSONGeometry: geoJSON2] description]);
 
-        XCTAssertTrue ([[[[GFBox alloc] initWithGeoJSONGeometry: geoJSON1] description] length] > 0);
-        XCTAssertTrue ([[[[GFBox alloc] initWithGeoJSONGeometry: geoJSON2] description] length] > 0);
+        XCTAssertEqualObjects([[[GFBox alloc] initWithGeoJSONGeometry: geoJSON1] description], @"POLYGON((100 0,100 1,101 1,101 0,100 0))");
+        XCTAssertEqualObjects([[[GFBox alloc] initWithGeoJSONGeometry: geoJSON2] description], @"POLYGON((103 2,103 4,110 4,110 2,103 2))");
     }
 
     - (void) testMapOverlays {

--- a/Example/Tests/Model/GFBoxTests.m
+++ b/Example/Tests/Model/GFBoxTests.m
@@ -1,5 +1,5 @@
 /*
-*   GFGeometryBoxTests.m
+*   GFBoxBoxTests.m
 *
 *   Copyright 2015 Tony Stone
 *
@@ -41,9 +41,9 @@ static NSString * invalidGeometryJSONString = @"{ \"type\": \"%@\","
 
         NSString * geoJSONGeometryName;
 
-        GFGeometry * geometry1a;
-        GFGeometry * geometry1b;
-        GFGeometry * geometry2;
+        GFBox * geometry1a;
+        GFBox * geometry1b;
+        GFBox * geometry2;
     }
 
     - (void)setUp {
@@ -52,9 +52,9 @@ static NSString * invalidGeometryJSONString = @"{ \"type\": \"%@\","
         expectedClass       = NSClassFromString( @"GFBox");
         geoJSONGeometryName = @"Box";
         
-        geometry1a = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-        geometry1b = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-        geometry2  = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry2JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
+        geometry1a = [[GFBox alloc] initWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
+        geometry1b = [[GFBox alloc] initWithGeoJSONGeometry:[NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
+        geometry2  = [[GFBox alloc] initWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry2JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
     }
 
     - (void)tearDown {
@@ -81,7 +81,7 @@ static NSString * invalidGeometryJSONString = @"{ \"type\": \"%@\","
 
         NSDictionary * testJSON  = [NSJSONSerialization JSONObjectWithData: [[NSString stringWithFormat:invalidGeometryJSONString, geoJSONGeometryName] dataUsingEncoding: NSUTF8StringEncoding]  options: 0 error: nil];
 
-        XCTAssertThrowsSpecificNamed([GFGeometry geometryWithGeoJSONGeometry: testJSON], NSException, @"Invalid GeoJSON");
+        XCTAssertThrowsSpecificNamed([GFBox geometryWithGeoJSONGeometry: testJSON], NSException, @"Invalid GeoJSON");
     }
 
     - (void) testDescription {

--- a/Example/Tests/Model/GFGeometryCollectionTests.m
+++ b/Example/Tests/Model/GFGeometryCollectionTests.m
@@ -26,6 +26,17 @@
 
 @implementation GFGeometryCollectionTests
 
+    - (void)testConstruction {
+        XCTAssertNoThrow([[GFGeometryCollection alloc] init]);
+        XCTAssertNotNil([[GFGeometryCollection alloc] init]);
+    }
+
+    - (void) testDescription {
+        XCTAssertEqualObjects([[[GFGeometryCollection alloc] initWithWKT:
+                @"GEOMETRYCOLLECTION(POLYGON((0 0,0 90,90 90,90 0,0 0)),POLYGON((120 0,120 90,210 90,210 0,120 0)),LINESTRING(40 50,40 140),LINESTRING(160 50,160 140),POINT(60 50),POINT(60 140),POINT(40 140))"] description],
+                @"GEOMETRYCOLLECTION(POLYGON((0 0,0 90,90 90,90 0,0 0)),POLYGON((120 0,120 90,210 90,210 0,120 0)),LINESTRING(40 50,40 140),LINESTRING(160 50,160 140),POINT(60 50),POINT(60 140),POINT(40 140))");
+    }
+
     - (void) testObjectAtIndexedSubscript {
 
         GFGeometryCollection * geometryCollection = [[GFGeometryCollection alloc] initWithWKT: @"GEOMETRYCOLLECTION(POLYGON((120 0,120 90,210 90,210 0,120 0)),LINESTRING(40 50,40 140))"];

--- a/Example/Tests/Model/GFLineStringTests.m
+++ b/Example/Tests/Model/GFLineStringTests.m
@@ -21,88 +21,46 @@
 #import <GeoFeatures/GeoFeatures.h>
 #import <XCTest/XCTest.h>
 
+static NSDictionary * geoJSON1;
+static NSDictionary * geoJSON2;
+static NSDictionary * invalidGeoJSON;
+
+//
+// Static constructor
+//
+static __attribute__((constructor(101),used,visibility("internal"))) void staticConstructor (void) {
+    geoJSON1       = @{@"type": @"LineString", @"coordinates": @[@[@(100.0), @(0.0)],@[@(101.0), @(1.0)]]};
+    geoJSON2       = @{@"type": @"LineString", @"coordinates": @[@[@(102.0), @(0.0)],@[@(102.0), @(1.0)]]};
+    invalidGeoJSON = @{@"type": @"LineString", @"coordinates": @{}};
+}
+
 @interface GFLineStringTests : XCTestCase
 @end
 
-static NSString * geometry1JSONString = @"{ \"type\": \"LineString\","
-        "    \"coordinates\": [ [100.0, 0.0], [101.0, 1.0] ]"
-        "}";
-
-static NSString * geometry2JSONString = @"{ \"type\": \"LineString\","
-        "    \"coordinates\": [ [102.0, 0.0], [102.0, 1.0] ]"
-        "}";
-
-static NSString * invalidGeometryJSONString = @"{ \"type\": \"%@\","
-        "    \"coordinates\": {}"
-        "   }";
-
-@implementation GFLineStringTests {
-        Class expectedClass;
-
-        NSString * geoJSONGeometryName;
-
-        GFGeometry * geometry1a;
-        GFGeometry * geometry1b;
-        GFGeometry * geometry2;
-    }
-
-    - (void)setUp {
-        [super setUp];
-
-        expectedClass       = NSClassFromString( @"GFLineString");
-        geoJSONGeometryName = @"LineString";
-        
-        geometry1a = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-        geometry1b = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-        geometry2  = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry2JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-    }
-
-    - (void)tearDown {
-
-        expectedClass       = nil;
-        geoJSONGeometryName = nil;
-        
-        geometry1a = nil;
-        geometry2           = nil;
-
-        [super tearDown];
-    }
+@implementation GFLineStringTests
 
     - (void)testConstruction {
 
-        XCTAssertNotNil(geometry1a);
-        XCTAssertNotNil(geometry2);
-
-        XCTAssertEqual([geometry1a class], expectedClass);
-        XCTAssertEqual([geometry2 class], expectedClass);
+        XCTAssertNoThrow([[GFLineString alloc] init]);
+        XCTAssertNotNil([[GFLineString alloc] init]);
     }
 
     - (void)testFailedConstruction {
-
-        NSDictionary * testJSON  = [NSJSONSerialization JSONObjectWithData: [[NSString stringWithFormat:invalidGeometryJSONString, geoJSONGeometryName] dataUsingEncoding: NSUTF8StringEncoding]  options: 0 error: nil];
-
-        XCTAssertThrowsSpecificNamed([GFGeometry geometryWithGeoJSONGeometry: testJSON], NSException, @"Invalid GeoJSON");
+        XCTAssertThrowsSpecificNamed([[GFLineString alloc] initWithGeoJSONGeometry: invalidGeoJSON], NSException, @"Invalid GeoJSON");
     }
 
     - (void) testToGeoJSONGeometry {
-
-        XCTAssertEqualObjects([geometry1a toGeoJSONGeometry], [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]);
+        XCTAssertEqualObjects([[[GFLineString alloc] initWithGeoJSONGeometry: geoJSON1] toGeoJSONGeometry], geoJSON1);
     }
 
     - (void) testDescription {
-
-        // Currently we only check if it returns something and its not nill
-
-        XCTAssertNotNil([geometry1a description]);
-        XCTAssertNotNil([geometry2 description]);
-
-        XCTAssertTrue ([[geometry1a description] length] > 0);
-        XCTAssertTrue ([[geometry2 description] length] > 0);
+        XCTAssertEqualObjects([[[GFLineString alloc] initWithGeoJSONGeometry: geoJSON1] description], @"LINESTRING(100 0,101 1)");
+        XCTAssertEqualObjects([[[GFLineString alloc] initWithGeoJSONGeometry: geoJSON2] description], @"LINESTRING(102 0,102 1)");
     }
 
     - (void) testMapOverlays {
     
-        NSArray * mapOverlays = [geometry1a mkMapOverlays];
+        NSArray * mapOverlays = [[[GFLineString alloc] initWithGeoJSONGeometry: geoJSON1] mkMapOverlays];
         
         XCTAssertNotNil (mapOverlays);
         XCTAssertTrue   ([mapOverlays count] == 1);

--- a/Example/Tests/Model/GFMultiLineStringTests.m
+++ b/Example/Tests/Model/GFMultiLineStringTests.m
@@ -21,100 +21,52 @@
 #import <GeoFeatures/GeoFeatures.h>
 #import <XCTest/XCTest.h>
 
+static NSDictionary * geoJSON1;
+static NSDictionary * geoJSON2;
+static NSDictionary * invalidGeoJSON;
+
+//
+// Static constructor
+//
+static __attribute__((constructor(101),used,visibility("internal"))) void staticConstructor (void) {
+    geoJSON1       = @{@"type": @"MultiLineString", @"coordinates": @[@[@[@(100.0), @(0.0)],@[@(101.0), @(1.0)]], @[@[@(102.0), @(2.0)],@[@(103.0), @(3.0)]]]};
+    geoJSON2       = @{@"type": @"MultiLineString", @"coordinates": @[@[@[@(103.0), @(2.0)],@[@(101.0), @(1.0)]], @[@[@(102.0), @(2.0)],@[@(103.0), @(3.0)]]]};
+    invalidGeoJSON = @{@"type": @"MultiLineString", @"coordinates": @{}};
+}
+
 @interface GFMultiLineStringTests : XCTestCase
 @end
 
-static NSString * geometry1JSONString = @"{ \"type\": \"MultiLineString\","
-        "    \"coordinates\": ["
-        "        [ [100.0, 0.0], [101.0, 1.0] ],"
-        "        [ [102.0, 2.0], [103.0, 3.0] ]"
-        "      ]"
-        "}";
-
-static NSString * geometry2JSONString = @"{ \"type\": \"MultiLineString\","
-        "    \"coordinates\": ["
-        "        [ [101.0, 0.0], [102.0, 1.0] ],"
-        "        [ [102.0, 2.0], [103.0, 3.0] ]"
-        "      ]"
-        "}";
-
-static NSString * invalidGeometryJSONString = @"{ \"type\": \"%@\","
-        "    \"coordinates\": {}"
-        "   }";
-
-@implementation GFMultiLineStringTests  {
-        Class expectedClass;
-
-        NSString * geoJSONGeometryName;
-
-        GFGeometry * geometry1a;
-        GFGeometry * geometry1b;
-        GFGeometry * geometry2;
-    }
-
-    - (void)setUp {
-        [super setUp];
-
-        expectedClass       = NSClassFromString( @"GFMultiLineString");
-        geoJSONGeometryName = @"MultiLineString";
-        
-        geometry1a = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-        geometry1b = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-        geometry2  = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry2JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-    }
-
-    - (void)tearDown {
-
-        expectedClass       = nil;
-        geoJSONGeometryName = nil;
-        
-        geometry1a = nil;
-        geometry2           = nil;
-
-        [super tearDown];
-    }
+@implementation GFMultiLineStringTests
 
     - (void)testConstruction {
 
-        XCTAssertNotNil(geometry1a);
-        XCTAssertNotNil(geometry2);
-
-        XCTAssertEqual([geometry1a class], expectedClass);
-        XCTAssertEqual([geometry2 class], expectedClass);
+        XCTAssertNoThrow([[GFMultiLineString alloc] init]);
+        XCTAssertNotNil([[GFMultiLineString alloc] init]);
     }
 
     - (void)testFailedConstruction {
-
-        NSDictionary * testJSON  = [NSJSONSerialization JSONObjectWithData: [[NSString stringWithFormat:invalidGeometryJSONString, geoJSONGeometryName] dataUsingEncoding: NSUTF8StringEncoding]  options: 0 error: nil];
-
-        XCTAssertThrowsSpecificNamed([GFGeometry geometryWithGeoJSONGeometry: testJSON], NSException, @"Invalid GeoJSON");
+        XCTAssertThrowsSpecificNamed([[GFMultiLineString alloc] initWithGeoJSONGeometry: invalidGeoJSON], NSException, @"Invalid GeoJSON");
     }
 
     - (void) testToGeoJSONGeometry {
-
-        XCTAssertEqualObjects([geometry1a toGeoJSONGeometry], [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]);
+        XCTAssertEqualObjects([[[GFMultiLineString alloc] initWithGeoJSONGeometry: geoJSON1] toGeoJSONGeometry], geoJSON1);
     }
 
     - (void) testDescription {
-
-        // Currently we only check if it returns something and its not nill
-
-        XCTAssertNotNil([geometry1a description]);
-        XCTAssertNotNil([geometry2 description]);
-
-        XCTAssertTrue ([[geometry1a description] length] > 0);
-        XCTAssertTrue ([[geometry2 description] length] > 0);
+        XCTAssertEqualObjects([[[GFMultiLineString alloc] initWithGeoJSONGeometry: geoJSON1] description], @"MULTILINESTRING((100 0,101 1),(102 2,103 3))");
+        XCTAssertEqualObjects([[[GFMultiLineString alloc] initWithGeoJSONGeometry: geoJSON2] description], @"MULTILINESTRING((103 2,101 1),(102 2,103 3))");
     }
 
     - (void) testMapOverlays {
         
-        NSArray * mapOverlays = [geometry1a mkMapOverlays];
+        NSArray * mapOverlays = [[[GFMultiLineString alloc] initWithGeoJSONGeometry: geoJSON1] mkMapOverlays];
         
         XCTAssertNotNil (mapOverlays);
         XCTAssertTrue   ([mapOverlays count] == 2);
         
         for (int i = 0; i < [mapOverlays count]; i++) {
-            id mapOverlay = [mapOverlays objectAtIndex: i];
+            id mapOverlay = mapOverlays[i];
             
             XCTAssertTrue   ([mapOverlay isKindOfClass: [MKPolyline class]]);
             

--- a/Example/Tests/Model/GFMultiPolygonTests.m
+++ b/Example/Tests/Model/GFMultiPolygonTests.m
@@ -21,102 +21,69 @@
 #import <GeoFeatures/GeoFeatures.h>
 #import <XCTest/XCTest.h>
 
+static NSDictionary * geoJSON1;
+static NSDictionary * geoJSON2;
+static NSDictionary * invalidGeoJSON;
+
+//
+// Static constructor
+//
+static __attribute__((constructor(101),used,visibility("internal"))) void staticConstructor (void) {
+    geoJSON1 = @{
+            @"type": @"MultiPolygon",
+            @"coordinates": @[
+                    @[
+                            @[@[@(102.0), @(2.0)], @[@(102.0), @(3.0)], @[@(103.0), @(3.0)], @[@(103.0), @(2.0)], @[@(102.0), @(2.0)]]
+                    ],
+                    @[
+                            @[@[@(100.0), @(0.0)], @[@(101.0), @(1.0)], @[@(100.0), @(1.0)], @[@(101.0), @(0.0)], @[@(100.0), @(0.0)]],
+                            @[@[@(100.2), @(0.2)], @[@(100.8), @(0.2)], @[@(100.8), @(0.8)], @[@(100.2), @(0.8)], @[@(100.2), @(0.2)]]
+                    ]
+            ]
+    };
+    geoJSON2 = @{
+            @"type" : @"MultiPolygon",
+            @"coordinates" : @[
+                    @[@[@[@(103.0), @(2.0)], @[@(104.0), @(2.0)], @[@(104.0), @(3.0)], @[@(103.0), @(3.0)], @[@(103.0), @(2.0)]]],
+                    @[@[@[@(100.0), @(0.0)], @[@(101.0), @(0.0)], @[@(101.0), @(1.0)], @[@(100.0), @(1.0)], @[@(100.0), @(0.0)]],
+                            @[@[@(100.2), @(0.2)], @[@(100.8), @(0.2)], @[@(100.8), @(0.8)], @[@(100.2), @(0.8)], @[@(100.2), @(0.2)]]]
+            ]
+    };
+
+    invalidGeoJSON = @{@"type": @"MultiLineString", @"coordinates": @{}};
+}
+
 @interface GFMultiPolygonTests : XCTestCase
 @end
 
-static NSString * geometry1JSONString = @"{ \"type\": \"MultiPolygon\","
-        "    \"coordinates\": ["
-        "      [[[102.0, 2.0], [102.0, 3.0], [103.0, 3.0], [103.0, 2.0], [102.0, 2.0]]],"
-        "      [[[100.0, 0.0], [101.0, 1.0], [100.0, 1.0], [101.0, 0.0], [100.0, 0.0]],"
-        "       [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]"
-        "      ]"
-        "    }";
-
-static NSString * geometry2JSONString = @"{ \"type\": \"MultiPolygon\","
-        "    \"coordinates\": ["
-        "      [[[103.0, 2.0], [104.0, 2.0], [104.0, 3.0], [103.0, 3.0], [103.0, 2.0]]],"
-        "      [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]],"
-        "       [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]"
-        "      ]"
-        "    }";
-
-static NSString * invalidGeometryJSONString = @"{ \"type\": \"%@\","
-        "    \"coordinates\": {}"
-        "   }";
-
-@implementation GFMultiPolygonTests {
-        Class expectedClass;
-
-        NSString * geoJSONGeometryName;
-
-        GFGeometry * geometry1a;
-        GFGeometry * geometry1b;
-        GFGeometry * geometry2;
-    }
-
-    - (void)setUp {
-        [super setUp];
-
-        expectedClass       = NSClassFromString( @"GFMultiPolygon");
-        geoJSONGeometryName = @"MultiPolygon";
-        
-        geometry1a = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-        geometry1b = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-        geometry2  = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry2JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-    }
-
-    - (void)tearDown {
-
-        expectedClass       = nil;
-        geoJSONGeometryName = nil;
-        
-        geometry1a = nil;
-        geometry2           = nil;
-
-        [super tearDown];
-    }
+@implementation GFMultiPolygonTests
 
     - (void)testConstruction {
-
-        XCTAssertNotNil(geometry1a);
-        XCTAssertNotNil(geometry2);
-
-        XCTAssertEqual([geometry1a class], expectedClass);
-        XCTAssertEqual([geometry2 class], expectedClass);
+        XCTAssertNoThrow([[GFMultiPolygon alloc] init]);
+        XCTAssertNotNil([[GFMultiPolygon alloc] init]);
     }
 
     - (void)testFailedConstruction {
-
-        NSDictionary * testJSON  = [NSJSONSerialization JSONObjectWithData: [[NSString stringWithFormat:invalidGeometryJSONString, geoJSONGeometryName] dataUsingEncoding: NSUTF8StringEncoding]  options: 0 error: nil];
-
-        XCTAssertThrowsSpecificNamed([GFGeometry geometryWithGeoJSONGeometry: testJSON], NSException, @"Invalid GeoJSON");
+        XCTAssertThrowsSpecificNamed([[GFMultiPolygon alloc] initWithGeoJSONGeometry: invalidGeoJSON], NSException, @"Invalid GeoJSON");
     }
 
     - (void) testToGeoJSONGeometry {
-
-        XCTAssertEqualObjects([geometry1a toGeoJSONGeometry], [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]);
+        XCTAssertEqualObjects([[[GFMultiPolygon alloc] initWithGeoJSONGeometry: geoJSON1] toGeoJSONGeometry], geoJSON1);
     }
 
     - (void) testDescription {
-
-        // Currently we only check if it returns something and its not nill
-
-        XCTAssertNotNil([geometry1a description]);
-        XCTAssertNotNil([geometry2 description]);
-
-        XCTAssertTrue ([[geometry1a description] length] > 0);
-        XCTAssertTrue ([[geometry2 description] length] > 0);
+        XCTAssertEqualObjects([[[GFMultiPolygon alloc] initWithWKT: @"MULTIPOLYGON(((20 0,20 10,40 10,40 0,20 0)),((5 5,5 8,8 8,8 5,5 5)))"] description], @"MULTIPOLYGON(((20 0,20 10,40 10,40 0,20 0)),((5 5,5 8,8 8,8 5,5 5)))");
     }
 
     - (void) testMapOverlays {
         
-        NSArray * mapOverlays = [geometry1a mkMapOverlays];
+        NSArray * mapOverlays = [[[GFMultiPolygon alloc] initWithGeoJSONGeometry: geoJSON1] mkMapOverlays];
         
         XCTAssertNotNil (mapOverlays);
         XCTAssertTrue   ([mapOverlays count] == 2);
         
         for (int i = 0; i < [mapOverlays count]; i++) {
-            id mapOverlay = [mapOverlays objectAtIndex: i];
+            id mapOverlay = mapOverlays[i];
             
             XCTAssertTrue   ([mapOverlay isKindOfClass: [MKPolygon class]]);
             

--- a/Example/Tests/Model/GFPointTests.m
+++ b/Example/Tests/Model/GFPointTests.m
@@ -21,88 +21,58 @@
 #import <GeoFeatures/GeoFeatures.h>
 #import <XCTest/XCTest.h>
 
+static NSDictionary * geoJSON1;
+static NSDictionary * geoJSON2;
+static NSDictionary * invalidGeoJSON;
+
+//
+// Static constructor
+//
+static __attribute__((constructor(101),used,visibility("internal"))) void staticConstructor (void) {
+    geoJSON1       = @{@"type": @"Point", @"coordinates": @[@(100.0), @(0.0)]};
+    geoJSON2       = @{@"type": @"Point", @"coordinates": @[@(103.0), @(2.0)]};
+    invalidGeoJSON = @{@"type": @"Point", @"coordinates": @{}};
+}
+
+
 @interface GFPointTests : XCTestCase
 @end
 
-static NSString * geometry1JSONString = @"{ \"type\": \"Point\", "
-        "    \"coordinates\": [100.0, 0.0] "
-        "}";
-
-static NSString * geometry2JSONString = @"{ \"type\": \"Point\", "
-        "    \"coordinates\": [103.0, 2.0] "
-        "}";
-
-static NSString * invalidGeometryJSONString = @"{ \"type\": \"%@\","
-        "    \"coordinates\": {}"
-        "   }";
-
-@implementation GFPointTests {
-        Class expectedClass;
-
-        NSString * geoJSONGeometryName;
-
-        GFGeometry * geometry1a;
-        GFGeometry * geometry1b;
-        GFGeometry * geometry2;
-    }
-
-    - (void)setUp {
-        [super setUp];
-
-        expectedClass       = NSClassFromString( @"GFPoint");
-        geoJSONGeometryName = @"Point";
-        
-        geometry1a = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-        geometry1b = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-        geometry2  = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry2JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-    }
-
-    - (void)tearDown {
-
-        expectedClass       = nil;
-        geoJSONGeometryName = nil;
-        
-        geometry1a = nil;
-        geometry2           = nil;
-
-        [super tearDown];
-    }
+@implementation GFPointTests
 
     - (void)testConstruction {
 
-        XCTAssertNotNil(geometry1a);
-        XCTAssertNotNil(geometry2);
+        XCTAssertNoThrow([[GFPoint alloc] init]);
+        XCTAssertNotNil([[GFPoint alloc] init]);
 
-        XCTAssertEqual([geometry1a class], expectedClass);
-        XCTAssertEqual([geometry2 class], expectedClass);
+        XCTAssertNoThrow([[GFPoint alloc] initWithX: 100.0 y:  0.0]);
+        XCTAssertNotNil([[GFPoint alloc] initWithX: 103.0 y:  2.0]);
+    }
+
+    - (void) testX {
+        XCTAssertEqual([[[GFPoint alloc] initWithX: 103.0 y:  2.0] x], 103.0);
+    }
+
+    - (void) testY {
+        XCTAssertEqual([[[GFPoint alloc] initWithX: 103.0 y:  2.0] y], 2.0);
     }
 
     - (void)testFailedConstruction {
-
-        NSDictionary * testJSON  = [NSJSONSerialization JSONObjectWithData: [[NSString stringWithFormat:invalidGeometryJSONString, geoJSONGeometryName] dataUsingEncoding: NSUTF8StringEncoding]  options: 0 error: nil];
-
-        XCTAssertThrowsSpecificNamed([GFGeometry geometryWithGeoJSONGeometry: testJSON], NSException, @"Invalid GeoJSON");
+        XCTAssertThrowsSpecificNamed([[GFPoint alloc] initWithGeoJSONGeometry: invalidGeoJSON], NSException, @"Invalid GeoJSON");
     }
 
     - (void) testToGeoJSONGeometry {
-
-        XCTAssertEqualObjects([geometry1a toGeoJSONGeometry], [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]);
+        XCTAssertEqualObjects([[[GFPoint alloc] initWithGeoJSONGeometry: geoJSON1] toGeoJSONGeometry], geoJSON1);
     }
 
     - (void) testDescription {
-
-        // Currently we only check if it returns something and its not nill
-
-        XCTAssertNotNil([geometry1a description]);
-        XCTAssertNotNil([geometry2 description]);
-
-        XCTAssertTrue ([[geometry1a description] length] > 0);
-        XCTAssertTrue ([[geometry2 description] length] > 0);
+        XCTAssertEqualObjects([[[GFPoint alloc] initWithGeoJSONGeometry: geoJSON1] description], @"POINT(100 0)");
+        XCTAssertEqualObjects([[[GFPoint alloc] initWithGeoJSONGeometry: geoJSON2] description], @"POINT(103 2)");
     }
 
     - (void) testMapOverlays {
     
-        NSArray * mapOverlays = [geometry1a mkMapOverlays];
+        NSArray * mapOverlays = [[[GFPoint alloc] initWithGeoJSONGeometry: geoJSON1] mkMapOverlays];
         
         XCTAssertNotNil (mapOverlays);
         XCTAssertTrue   ([mapOverlays count] == 1);

--- a/Example/Tests/Model/GFPolygonTests.m
+++ b/Example/Tests/Model/GFPolygonTests.m
@@ -21,93 +21,56 @@
 #import <GeoFeatures/GeoFeatures.h>
 #import <XCTest/XCTest.h>
 
+static NSDictionary * geoJSON1;
+static NSDictionary * geoJSON2;
+static NSDictionary * invalidGeoJSON;
+
+//
+// Static constructor
+//
+static __attribute__((constructor(101),used,visibility("internal"))) void staticConstructor (void) {
+    geoJSON1       = @{@"type": @"Polygon",
+                      @"coordinates": @[
+                        @[ @[@(100.0), @(0.0)], @[@(200.0), @(100.0)],@[@(200.0), @(0.0)], @[@(100.0), @(1.0)], @[@(100.0), @(0.0)] ],
+                        @[ @[@(100.2), @(0.2)], @[@(100.8), @(0.2)],  @[@(100.8), @(0.8)], @[@(100.2), @(0.8)], @[@(100.2), @(0.2)] ]
+                        ]
+                    };
+    geoJSON2       = @{@"type": @"Polygon",
+                         @"coordinates": @[
+                            @[ @[@(98.0), @(0.0)], @[@(101.0), @(1.0)],@[@(101.0), @(0.0)], @[@(98.0), @(1.0)], @[@(98.0), @(0.0)] ]
+                        ]
+                    };
+    invalidGeoJSON = @{@"type": @"Polygon", @"coordinates": @{}};
+}
+
 @interface GFPolygonTests : XCTestCase
 @end
 
-static NSString * geometry1JSONString = @"{ \"type\": \"Polygon\","
-        "    \"coordinates\": ["
-        "      [ [100.0, 0.0], [200.0, 100.0],[200.0, 0.0], [100.0, 1.0], [100.0, 0.0] ],"
-        "      [ [100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2] ]"
-        "      ]"
-        "   }";
 
-static NSString * geometry2JSONString = @"{ \"type\": \"Polygon\","
-        "    \"coordinates\": ["
-        "      [ [98.0, 0.0], [101.0, 0.0], [101.0, 1.0], [98.0, 1.0], [98.0, 0.0] ]"
-        "      ]"
-        "   }";
-
-static NSString * invalidGeometryJSONString = @"{ \"type\": \"%@\","
-        "    \"coordinates\": {}"
-        "   }";
-
-@implementation GFPolygonTests {
-        Class expectedClass;
-
-        NSString * geoJSONGeometryName;
-
-        GFGeometry * geometry1a;
-        GFGeometry * geometry1b;
-        GFGeometry * geometry2;
-    }
-
-    - (void)setUp {
-        [super setUp];
-
-        expectedClass       = NSClassFromString( @"GFPolygon");
-        geoJSONGeometryName = @"Polygon";
-        
-        geometry1a = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-        geometry1b = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-        geometry2  = [GFGeometry geometryWithGeoJSONGeometry: [NSJSONSerialization JSONObjectWithData: [geometry2JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]];
-    }
-
-    - (void)tearDown {
-
-        expectedClass       = nil;
-        geoJSONGeometryName = nil;
-        
-        geometry1a = nil;
-        geometry2           = nil;
-
-        [super tearDown];
-    }
+@implementation GFPolygonTests
 
     - (void)testConstruction {
 
-        XCTAssertNotNil(geometry1a);
-        XCTAssertNotNil(geometry2);
-
-        XCTAssertEqual([geometry1a class], expectedClass);
-        XCTAssertEqual([geometry2 class], expectedClass);
+        XCTAssertNotNil([[GFPolygon alloc] init]);
+        XCTAssertNotNil([[GFPolygon alloc] init]);
     }
 
     - (void)testFailedConstruction {
-
-        NSDictionary * testJSON  = [NSJSONSerialization JSONObjectWithData: [[NSString stringWithFormat:invalidGeometryJSONString, geoJSONGeometryName] dataUsingEncoding: NSUTF8StringEncoding]  options: 0 error: nil];
-
-        XCTAssertThrowsSpecificNamed([GFGeometry geometryWithGeoJSONGeometry: testJSON], NSException, @"Invalid GeoJSON");
+        XCTAssertThrowsSpecificNamed([[GFPolygon alloc] initWithGeoJSONGeometry: invalidGeoJSON], NSException, @"Invalid GeoJSON");
     }
 
     - (void) testToGeoJSONGeometry {
-
-        XCTAssertEqualObjects([geometry1a toGeoJSONGeometry], [NSJSONSerialization JSONObjectWithData: [geometry1JSONString dataUsingEncoding: NSUTF8StringEncoding] options: 0 error: nil]);
+        XCTAssertEqualObjects([[[GFPolygon alloc] initWithGeoJSONGeometry: geoJSON1] toGeoJSONGeometry], geoJSON1);
     }
 
     - (void) testDescription {
-
-        // Currently we only check if it returns something and its not nill
-
-        XCTAssertNotNil([geometry1a description]);
-        XCTAssertNotNil([geometry2 description]);
-
-        XCTAssertTrue ([[geometry1a description] length] > 0);
-        XCTAssertTrue ([[geometry2 description] length] > 0);
+        XCTAssertEqualObjects([[[GFPolygon alloc] initWithGeoJSONGeometry: geoJSON1] description], @"POLYGON((100 0,200 100,200 0,100 1,100 0),(100.2 0.2,100.8 0.2,100.8 0.8,100.2 0.8,100.2 0.2))");
+        XCTAssertEqualObjects([[[GFPolygon alloc] initWithGeoJSONGeometry: geoJSON2] description], @"POLYGON((98 0,101 1,101 0,98 1,98 0))");
     }
 
     - (void) testMapOverlays {
     
-        NSArray * mapOverlays = [geometry1a mkMapOverlays];
+        NSArray * mapOverlays = [[[GFPolygon alloc] initWithGeoJSONGeometry: geoJSON1]  mkMapOverlays];
         
         XCTAssertNotNil (mapOverlays);
         XCTAssertTrue   ([mapOverlays count] == 1);


### PR DESCRIPTION
- Change test types to explicate types instead of GFGeometry. This should help test coverage be more accurate.
- Changed test JSON from NSString to NSDictionary representations.
- Changed testToGeoJSONGeometry to compare the GeoJSON dictionary returned.
- Added no arg init test.
- Changed testDescription to compare the WKT string returned to an actual string.
