### PR TITLE
Abstract class tests & bug fixes for abstract init

### DIFF
--- a/Example/GeoFeatures.xcodeproj/project.pbxproj
+++ b/Example/GeoFeatures.xcodeproj/project.pbxproj
@@ -13,12 +13,15 @@
 		3669821F3CEFEF4B6F458D14 /* GFMultiPolygonTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3669866E55BBAB7FE20F06C7 /* GFMultiPolygonTests.m */; };
 		3669828B7E7F987193664354 /* NSString+CaseInsensitiveHasPrefixTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 36698B9400DAEAE50985F8B4 /* NSString+CaseInsensitiveHasPrefixTests.m */; };
 		366982BCCAC434E702E20896 /* GFLineStringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 36698CCB90E1B4DC9F9DD6AF /* GFLineStringTests.m */; };
+		3669836B4BAC01B742CBAB72 /* GFPointAbstractTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 36698D7F428C0932B157DBDB /* GFPointAbstractTests.m */; };
+		366985884DA03B6774617494 /* GFPolygonAbstractTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3669840BBD50B8C394F05B93 /* GFPolygonAbstractTests.m */; };
 		366985E09B9633326DB82E12 /* GFIsValidTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3669818456264350A29F3AEB /* GFIsValidTests.m */; };
 		3669866AF010812E23F9F2EE /* GFPointTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 36698907141EECAB15ED39DF /* GFPointTests.m */; };
 		36698699B44CF23FF9319C66 /* GFCentroidTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 36698C3FE1385E161EB5A0A7 /* GFCentroidTests.m */; };
 		36698730DE766EC3201B61FB /* GFBoxTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3669841D7B352FD8D549B9CE /* GFBoxTests.m */; };
 		366987514BC49B634F8FAB3C /* GFAreaTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 36698EBD18A1228C9719FE73 /* GFAreaTests.m */; };
 		366987B4790476C2AA46A086 /* GFPolygonTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 36698EA5DB721C9CE82CD242 /* GFPolygonTests.m */; };
+		3669892241E56291821679FA /* GFLineStringAbstractTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 36698BCEB85EDBF2042502F4 /* GFLineStringAbstractTests.m */; };
 		36698A000919EEEA85208C76 /* GFBoundingBoxTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 36698E4DA2252BF2E0933035 /* GFBoundingBoxTests.m */; };
 		36698B38A8D25E4B5A17B997 /* GFEncodingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 36698FF5EDACF80E61C3CF4F /* GFEncodingTest.m */; };
 		36698BE95B098F31453A03FA /* GFMultiPointTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 36698FECBDE3474A6A4A674D /* GFMultiPointTests.m */; };
@@ -60,6 +63,7 @@
 		22529FD0A77AEC89DC728E5F /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		366981225BFB9BEBE9A3B512 /* GFWKTTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFWKTTests.m; sourceTree = "<group>"; };
 		3669818456264350A29F3AEB /* GFIsValidTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFIsValidTests.m; sourceTree = "<group>"; };
+		3669840BBD50B8C394F05B93 /* GFPolygonAbstractTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFPolygonAbstractTests.m; sourceTree = "<group>"; };
 		3669841D7B352FD8D549B9CE /* GFBoxTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFBoxTests.m; sourceTree = "<group>"; };
 		36698619C66272CA2645EC9E /* GFUnionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFUnionTests.m; sourceTree = "<group>"; };
 		3669866E55BBAB7FE20F06C7 /* GFMultiPolygonTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFMultiPolygonTests.m; sourceTree = "<group>"; };
@@ -70,9 +74,11 @@
 		366989CE6B97F08360CFFDDC /* GFMultiLineStringTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFMultiLineStringTests.m; sourceTree = "<group>"; };
 		36698A93346A44A8E5779C88 /* GFGeometryCollectionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFGeometryCollectionTests.m; sourceTree = "<group>"; };
 		36698B9400DAEAE50985F8B4 /* NSString+CaseInsensitiveHasPrefixTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSString+CaseInsensitiveHasPrefixTests.m"; path = "Internal/NSString+CaseInsensitiveHasPrefixTests.m"; sourceTree = "<group>"; };
+		36698BCEB85EDBF2042502F4 /* GFLineStringAbstractTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFLineStringAbstractTests.m; sourceTree = "<group>"; };
 		36698C3FE1385E161EB5A0A7 /* GFCentroidTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFCentroidTests.m; sourceTree = "<group>"; };
 		36698CCB90E1B4DC9F9DD6AF /* GFLineStringTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFLineStringTests.m; sourceTree = "<group>"; };
 		36698D1BBEB6C10EB3476B2C /* GFWithinTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFWithinTests.m; sourceTree = "<group>"; };
+		36698D7F428C0932B157DBDB /* GFPointAbstractTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFPointAbstractTests.m; sourceTree = "<group>"; };
 		36698E4DA2252BF2E0933035 /* GFBoundingBoxTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFBoundingBoxTests.m; sourceTree = "<group>"; };
 		36698EA5DB721C9CE82CD242 /* GFPolygonTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFPolygonTests.m; sourceTree = "<group>"; };
 		36698EBD18A1228C9719FE73 /* GFAreaTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GFAreaTests.m; sourceTree = "<group>"; };
@@ -173,6 +179,9 @@
 				366989CE6B97F08360CFFDDC /* GFMultiLineStringTests.m */,
 				36698A93346A44A8E5779C88 /* GFGeometryCollectionTests.m */,
 				36698879AFDB8DC101C0F624 /* GFGeometryTests.m */,
+				36698D7F428C0932B157DBDB /* GFPointAbstractTests.m */,
+				36698BCEB85EDBF2042502F4 /* GFLineStringAbstractTests.m */,
+				3669840BBD50B8C394F05B93 /* GFPolygonAbstractTests.m */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -472,6 +481,9 @@
 				3669808E58860FC07296186F /* GFGeometryCollectionTests.m in Sources */,
 				3669828B7E7F987193664354 /* NSString+CaseInsensitiveHasPrefixTests.m in Sources */,
 				EAA463721B9E60DE00ADEC86 /* GFGeometryTests.m in Sources */,
+				3669836B4BAC01B742CBAB72 /* GFPointAbstractTests.m in Sources */,
+				3669892241E56291821679FA /* GFLineStringAbstractTests.m in Sources */,
+				366985884DA03B6774617494 /* GFPolygonAbstractTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Tests/Model/GFLineStringAbstractTests.m
+++ b/Example/Tests/Model/GFLineStringAbstractTests.m
@@ -1,0 +1,40 @@
+/*
+*   GFLineStringAbstract.m
+*
+*   Copyright 2015 Tony Stone
+*
+*   Licensed under the Apache License, Version 2.0 (the "License");
+*   you may not use this file except in compliance with the License.
+*   You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*   See the License for the specific language governing permissions and
+*   limitations under the License.
+*
+*   Created by Tony Stone on 09/08/2015.
+*/
+
+#import <GeoFeatures/GFLineStringAbstract.h>
+#import <XCTest/XCTest.h>
+
+@interface GFLineStringAbstractTests : XCTestCase
+@end
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+@implementation GFLineStringAbstractTests
+
+    - (void)testConstruction {
+
+        XCTAssertThrows([[GFLineStringAbstract alloc] init]);
+    }
+
+@end
+
+#pragma clang diagnostic pop
+

--- a/Example/Tests/Model/GFPointAbstractTests.m
+++ b/Example/Tests/Model/GFPointAbstractTests.m
@@ -1,0 +1,38 @@
+/*
+*   GFPointAbstractTests.m
+*
+*   Copyright 2015 Tony Stone
+*
+*   Licensed under the Apache License, Version 2.0 (the "License");
+*   you may not use this file except in compliance with the License.
+*   You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*   See the License for the specific language governing permissions and
+*   limitations under the License.
+*
+*   Created by Tony Stone on 09/08/2015.
+*/
+
+#import <GeoFeatures/GFPointAbstract.h>
+#import <XCTest/XCTest.h>
+
+@interface GFPointAbstractTests : XCTestCase
+@end
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+@implementation GFPointAbstractTests
+
+    - (void)testConstruction {
+        XCTAssertThrows([[GFPointAbstract alloc] init]);
+    }
+
+@end
+
+#pragma clang diagnostic pop

--- a/Example/Tests/Model/GFPolygonAbstractTests.m
+++ b/Example/Tests/Model/GFPolygonAbstractTests.m
@@ -1,0 +1,40 @@
+/*
+*   GFPolygonAbstractTests.m
+*
+*   Copyright 2015 Tony Stone
+*
+*   Licensed under the Apache License, Version 2.0 (the "License");
+*   you may not use this file except in compliance with the License.
+*   You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*   See the License for the specific language governing permissions and
+*   limitations under the License.
+*
+*   Created by Tony Stone on 09/08/2015.
+*/
+
+#import <GeoFeatures/GFPolygonAbstract.h>
+#import <XCTest/XCTest.h>
+
+@interface GFPolygonAbstractTests : XCTestCase
+@end
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+@implementation GFPolygonAbstractTests
+
+    - (void)testConstruction {
+
+        XCTAssertThrows([[GFPolygonAbstract alloc] init]);
+    }
+
+@end
+
+#pragma clang diagnostic pop
+

--- a/GeoFeatures/GFLineStringAbstract.mm
+++ b/GeoFeatures/GFLineStringAbstract.mm
@@ -42,7 +42,7 @@ namespace gf = geofeatures::internal;
 @implementation GFLineStringAbstract (Protected)
 
     - (instancetype) init {
-        NSAssert(![[self class] isMemberOfClass: [GFLineStringAbstract class]], @"Abstract class %@ can not be instantiated.  Please use one of the subclasses instead.", NSStringFromClass([self class]));
+        NSAssert(![self isMemberOfClass: [GFLineStringAbstract class]], @"Abstract class %@ can not be instantiated.  Please use one of the subclasses instead.", NSStringFromClass([self class]));
         return nil;
     }
 

--- a/GeoFeatures/GFPointAbstract.mm
+++ b/GeoFeatures/GFPointAbstract.mm
@@ -36,7 +36,7 @@ namespace gf = geofeatures::internal;
 @implementation GFPointAbstract (Protected)
 
     - (instancetype) init {
-        NSAssert(![[self class] isMemberOfClass: [GFPointAbstract class]], @"Abstract class %@ can not be instantiated.  Please use one of the subclasses instead.", NSStringFromClass([self class]));
+        NSAssert(![self isMemberOfClass: [GFPointAbstract class]], @"Abstract class %@ can not be instantiated.  Please use one of the subclasses instead.", NSStringFromClass([self class]));
         return nil;
     }
 

--- a/GeoFeatures/GFPolygonAbstract.mm
+++ b/GeoFeatures/GFPolygonAbstract.mm
@@ -42,7 +42,7 @@ namespace gf = geofeatures::internal;
 @implementation GFPolygonAbstract (Protected)
 
     - (instancetype) init {
-        NSAssert(![[self class] isMemberOfClass: [GFPolygonAbstract class]], @"Abstract class %@ can not be instantiated.  Please use one of the subclasses instead.", NSStringFromClass([self class]));
+        NSAssert(![self isMemberOfClass: [GFPolygonAbstract class]], @"Abstract class %@ can not be instantiated.  Please use one of the subclasses instead.", NSStringFromClass([self class]));
         return nil;
     }
 


### PR DESCRIPTION
## Add Abstract class tests
- Added abstract class tests for GFPointAbstract, GFLineStringAbstract, and GFPolygonAbstract classes.
## Fixed bug found by adding adding tests.
- Fixed issue with allowing Abstract class init found in commit 1b1715a.
