### PR TITLE
Fix GFGeometry init

### DIFF
--- a/Example/GeoFeatures.xcodeproj/xcshareddata/xcschemes/GeoFeatures-Example.xcscheme
+++ b/Example/GeoFeatures.xcodeproj/xcshareddata/xcschemes/GeoFeatures-Example.xcscheme
@@ -36,11 +36,6 @@
                BlueprintName = "Tests"
                ReferencedContainer = "container:GeoFeatures.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "GFGeometryTests">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>

--- a/Example/Tests/Model/GFGeometryTests.m
+++ b/Example/Tests/Model/GFGeometryTests.m
@@ -31,6 +31,10 @@
 
 @implementation GFGeometryTests
 
+    - (void)testFailedConstruction {
+        XCTAssertThrowsSpecificNamed([[GFGeometry alloc] init], NSException, NSInternalInconsistencyException);
+    }
+
     - (void) testGeometryWithWKT {
         GeometryWithWKTTest (@"POINT(1 1)");
         GeometryWithWKTTest2(@"POINT()", @"POINT(0 0)");

--- a/GeoFeatures/GFGeometry.mm
+++ b/GeoFeatures/GFGeometry.mm
@@ -55,7 +55,7 @@ namespace  gf = geofeatures::internal;
 @implementation GFGeometry
 
     - (instancetype) init {
-        NSAssert(![[self class] isMemberOfClass: [GFGeometry class]], @"Abstract class %@ can not be instantiated.  Please use one of the subclasses instead.", NSStringFromClass([self class]));
+        NSAssert(![self isMemberOfClass: [GFGeometry class]], @"Abstract class %@ can not be instantiated.  Please use one of the subclasses instead.", NSStringFromClass([self class]));
         return nil;
     }
 


### PR DESCRIPTION
## Update GFGeometry.mm
- Fixed bug where init of a GFGeometry class directly was allowed.
## Update GFGeometryTests.m
- Added test for init on GFGeometry instance.
## Update GeoFeatures project
- Enabled GFGeometryTests.m.
