### PR TITLE
Increasing coverage by testing invalid WKT init.

### DIFF
--- a/Example/Tests/Model/GFBoxTests.m
+++ b/Example/Tests/Model/GFBoxTests.m
@@ -53,6 +53,7 @@ static __attribute__((constructor(101),used,visibility("internal"))) void static
 
     - (void)testFailedConstruction {
         XCTAssertThrowsSpecificNamed([[GFBox alloc] initWithGeoJSONGeometry: invalidGeoJSON], NSException, @"Invalid GeoJSON");
+        XCTAssertThrows([[GFBox alloc] initWithWKT: @"INVALID()"]);
     }
 
     - (void) testToGeoJSONGeometry  {

--- a/Example/Tests/Model/GFGeometryCollectionTests.m
+++ b/Example/Tests/Model/GFGeometryCollectionTests.m
@@ -39,6 +39,8 @@
 
         XCTAssertThrowsSpecificNamed([[GFGeometryCollection alloc] initWithArray: (@[ [[GFGeometryCollection alloc] initWithWKT: @"GEOMETRYCOLLECTION(POLYGON((120 0,120 90,210 90,210 0,120 0)),LINESTRING(40 50,40 140))"]])], NSException, NSInvalidArgumentException);
         XCTAssertThrowsSpecificNamed([[GFGeometryCollection alloc] initWithArray: @[[[NSObject alloc] init]]], NSException, NSInvalidArgumentException);
+
+        XCTAssertThrows([[GFGeometryCollection alloc] initWithWKT: @"INVALID()"]);
     }
 
     - (void) testDescription {

--- a/Example/Tests/Model/GFGeometryTests.m
+++ b/Example/Tests/Model/GFGeometryTests.m
@@ -56,6 +56,7 @@
 
     - (void)testFailedConstruction {
         XCTAssertThrowsSpecificNamed([[GFGeometry alloc] init], NSException, NSInternalInconsistencyException);
+        XCTAssertThrows([[GFGeometry alloc] initWithWKT: @"INVALID()"]);
     }
 
     - (void) testGeometryWithWKT {

--- a/Example/Tests/Model/GFLineStringTests.m
+++ b/Example/Tests/Model/GFLineStringTests.m
@@ -47,6 +47,7 @@ static __attribute__((constructor(101),used,visibility("internal"))) void static
 
     - (void)testFailedConstruction {
         XCTAssertThrowsSpecificNamed([[GFLineString alloc] initWithGeoJSONGeometry: invalidGeoJSON], NSException, @"Invalid GeoJSON");
+        XCTAssertThrows([[GFLineString alloc] initWithWKT: @"INVALID()"]);
     }
 
     - (void) testToGeoJSONGeometry {

--- a/Example/Tests/Model/GFMultiLineStringTests.m
+++ b/Example/Tests/Model/GFMultiLineStringTests.m
@@ -47,6 +47,7 @@ static __attribute__((constructor(101),used,visibility("internal"))) void static
 
     - (void)testFailedConstruction {
         XCTAssertThrowsSpecificNamed([[GFMultiLineString alloc] initWithGeoJSONGeometry: invalidGeoJSON], NSException, @"Invalid GeoJSON");
+        XCTAssertThrows([[GFMultiLineString alloc] initWithWKT: @"INVALID()"]);
     }
 
     - (void) testToGeoJSONGeometry {

--- a/Example/Tests/Model/GFMultiPointTests.m
+++ b/Example/Tests/Model/GFMultiPointTests.m
@@ -47,6 +47,7 @@ static __attribute__((constructor(101),used,visibility("internal"))) void static
 
     - (void)testFailedConstruction {
         XCTAssertThrowsSpecificNamed([[GFMultiPoint alloc] initWithGeoJSONGeometry: invalidGeoJSON], NSException, @"Invalid GeoJSON");
+        XCTAssertThrows([[GFMultiPoint alloc] initWithWKT: @"INVALID()"]);
     }
 
     - (void) testToGeoJSONGeometry {

--- a/Example/Tests/Model/GFMultiPolygonTests.m
+++ b/Example/Tests/Model/GFMultiPolygonTests.m
@@ -65,6 +65,7 @@ static __attribute__((constructor(101),used,visibility("internal"))) void static
 
     - (void)testFailedConstruction {
         XCTAssertThrowsSpecificNamed([[GFMultiPolygon alloc] initWithGeoJSONGeometry: invalidGeoJSON], NSException, @"Invalid GeoJSON");
+        XCTAssertThrows([[GFMultiPolygon alloc] initWithWKT: @"INVALID()"]);
     }
 
     - (void) testToGeoJSONGeometry {

--- a/Example/Tests/Model/GFPointTests.m
+++ b/Example/Tests/Model/GFPointTests.m
@@ -59,6 +59,7 @@ static __attribute__((constructor(101),used,visibility("internal"))) void static
 
     - (void)testFailedConstruction {
         XCTAssertThrowsSpecificNamed([[GFPoint alloc] initWithGeoJSONGeometry: invalidGeoJSON], NSException, @"Invalid GeoJSON");
+        XCTAssertThrows([[GFPoint alloc] initWithWKT: @"INVALID()"]);
     }
 
     - (void) testToGeoJSONGeometry {

--- a/Example/Tests/Model/GFPolygonTests.m
+++ b/Example/Tests/Model/GFPolygonTests.m
@@ -57,6 +57,7 @@ static __attribute__((constructor(101),used,visibility("internal"))) void static
 
     - (void)testFailedConstruction {
         XCTAssertThrowsSpecificNamed([[GFPolygon alloc] initWithGeoJSONGeometry: invalidGeoJSON], NSException, @"Invalid GeoJSON");
+        XCTAssertThrows([[GFPolygon alloc] initWithWKT: @"INVALID()"]);
     }
 
     - (void) testToGeoJSONGeometry {

--- a/Example/Tests/Model/GFRingTests.m
+++ b/Example/Tests/Model/GFRingTests.m
@@ -49,6 +49,7 @@ void __attribute__((constructor)) staticInitializer() {
 
     - (void)testFailedConstruction {
         XCTAssertThrowsSpecificNamed(([GFGeometry geometryWithGeoJSONGeometry: @{@"type": @"LineString",@"coordinates": @{}}]), NSException, @"Invalid GeoJSON");
+        XCTAssertThrows([[GFRing alloc] initWithWKT: @"INVALID()"]);
     }
 
     - (void) testDescription {

--- a/GeoFeatures/Internal/geofeatures/internal/io/wkt/ReadWKT.hpp
+++ b/GeoFeatures/Internal/geofeatures/internal/io/wkt/ReadWKT.hpp
@@ -40,6 +40,10 @@ namespace geofeatures {
         template <typename Geometry, typename = typename std::enable_if<std::is_same<Geometry,GeometryCollection>::value>::type>
         inline void readWKT(std::string const &wkt, Geometry &geometryCollection)
         {
+            if (!boost::istarts_with(wkt, "GEOMETRYCOLLECTION")) {
+                throw std::invalid_argument("Should start with 'GEOMETRYCOLLECTION'' in (" + wkt + ")");
+            }
+            
             GeometryCollectionVariantType (*geometry)(std::string & wkt) =
                         [](std::string & wkt) -> GeometryCollectionVariantType {
 
@@ -82,7 +86,7 @@ namespace geofeatures {
                             }
                             return GeometryCollectionVariantType();
                         };
-
+            
                 std::regex words_regex("\\b(EMPTY|POINT|MULTIPOINT|LINESTRING|MULTILINESTRING|POLYGON)", std::regex_constants::icase);
             
                 std::string::const_iterator collectionBegin = wkt.begin();


### PR DESCRIPTION
- Fixed GFGeometryCollection initWithWKT on invalid wit, was not throwing.
