### PR TITLE
Rework C++ model

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -976,6 +976,9 @@
 		361F599C68C43B15B536FB94 /* dinkumware.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 89C0AD00CF453D72E1A48664 /* dinkumware.hpp */; };
 		362B12C07531F838FF62F071 /* distance_projected_point.hpp in Headers */ = {isa = PBXBuildFile; fileRef = BF37345A33947E497703B154 /* distance_projected_point.hpp */; };
 		3661AA84FFCD3F2628777CF7 /* add_pointer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 25C5961B733822241B05CEF2 /* add_pointer.hpp */; };
+		3669800B7250C3F13C815FF7 /* Allocator.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 36698EA50878836D72179233 /* Allocator.hpp */; };
+		366982310B19662E795EDBA6 /* Collection.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 366980ED54EB5C95927F6627 /* Collection.hpp */; };
+		36698452B83F2236F561B94D /* Collection.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 366980ED54EB5C95927F6627 /* Collection.hpp */; };
 		3672B2037F8B7927A2F4C02F /* list_c.hpp in Headers */ = {isa = PBXBuildFile; fileRef = B96D1D3207C4B95CF8C36E58 /* list_c.hpp */; };
 		36AC075AC5A3F5AA154A22E0 /* list_c.hpp in Headers */ = {isa = PBXBuildFile; fileRef = BADEE0891224A41A3CAD4A25 /* list_c.hpp */; };
 		36B54501C4322908FF74DF52 /* register_mem_functions.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F63ED36B8809DE2FA05A5692 /* register_mem_functions.hpp */; };
@@ -5366,6 +5369,8 @@
 		36288A71AB669836D0A96D88 /* cxx.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = cxx.h; sourceTree = "<group>"; };
 		363169E7974875E97BD4CE30 /* move.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; path = move.hpp; sourceTree = "<group>"; };
 		36397A30E514E7D2B709C346 /* comma_if.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; path = comma_if.hpp; sourceTree = "<group>"; };
+		366980ED54EB5C95927F6627 /* Collection.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Collection.hpp; sourceTree = "<group>"; };
+		36698EA50878836D72179233 /* Allocator.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Allocator.hpp; sourceTree = "<group>"; };
 		3673553179A9F2A1B877E834 /* apply.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; path = apply.hpp; sourceTree = "<group>"; };
 		36A555B9D13D20385553EE01 /* get_max_size.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; path = get_max_size.hpp; sourceTree = "<group>"; };
 		36A6219939F1C13A04AC3457 /* times.hpp */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.h; path = times.hpp; sourceTree = "<group>"; };
@@ -9397,6 +9402,8 @@
 				ED4F593912507EF359D577D1 /* Ring.hpp */,
 				434328B9A6B048592DE85DAA /* io */,
 				FE11A5316F2324570CB964AA /* operators */,
+				36698EA50878836D72179233 /* Allocator.hpp */,
+				366980ED54EB5C95927F6627 /* Collection.hpp */,
 			);
 			path = geofeatures;
 			sourceTree = "<group>";
@@ -13991,6 +13998,7 @@
 				B971E17D3D81FCDF4A539028 /* yield_k.hpp in Headers */,
 				826619C1F14C61B5E6A615FF /* z.h in Headers */,
 				D113AEE11124176CD77E82AB /* zos.h in Headers */,
+				36698452B83F2236F561B94D /* Collection.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -16389,6 +16397,8 @@
 				39191A456CFF6872A83BF785 /* yield_k.hpp in Headers */,
 				2540BECB888BE2086BBDD53C /* z.h in Headers */,
 				E76FD18BF5E2848B5F0CB8CD /* zos.h in Headers */,
+				3669800B7250C3F13C815FF7 /* Allocator.hpp in Headers */,
+				366982310B19662E795EDBA6 /* Collection.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GeoFeatures/GFGeometryCollection.mm
+++ b/GeoFeatures/GFGeometryCollection.mm
@@ -32,7 +32,7 @@
 namespace gf = geofeatures;
 
 @implementation GFGeometryCollection {
-        gf::GeometryCollection  _geometryCollection;
+        gf::GeometryCollection<>  _geometryCollection;
     }
 
 #pragma mark - Public methods
@@ -139,7 +139,7 @@ namespace gf = geofeatures;
 
 @implementation GFGeometryCollection (Protected)
 
-    - (instancetype) initWithCPPGeometryCollection: (gf::GeometryCollection) aGeometryCollection {
+    - (instancetype) initWithCPPGeometryCollection: (gf::GeometryCollection<>) aGeometryCollection {
 
         if (self = [super init]) {
             _geometryCollection = aGeometryCollection;

--- a/GeoFeatures/GFPolygon.mm
+++ b/GeoFeatures/GFPolygon.mm
@@ -83,7 +83,7 @@ namespace gf = geofeatures;
     }
 
     - (GFGeometryCollection *) innerRings {
-        gf::GeometryCollection geometryCollection;
+        gf::GeometryCollection<> geometryCollection;
 
         const auto& inners  = _polygon.inners();
 

--- a/GeoFeatures/Internal/GFGeometry+Protected.hpp
+++ b/GeoFeatures/Internal/GFGeometry+Protected.hpp
@@ -94,7 +94,7 @@ namespace geofeatures {
         GFGeometry * operator()(const MultiPolygon & v) const {
             return [[::GFMultiPolygon alloc] initWithCPPMultiPolygon: v];
         }
-        GFGeometry * operator()(const GeometryCollection & v) const {
+        GFGeometry * operator()(const GeometryCollection<> & v) const {
             return [[::GFGeometryCollection alloc] initWithCPPGeometryCollection: v];
         }
     };

--- a/GeoFeatures/Internal/GFGeometryCollection+Protected.hpp
+++ b/GeoFeatures/Internal/GFGeometryCollection+Protected.hpp
@@ -25,10 +25,8 @@
 #import <Foundation/Foundation.h>
 #import "GFGeometryCollection.h"
 
-namespace geofeatures {
-    // Forward declarations
-    class GeometryCollection;
-}
+// Note: we must specifically include GeometryCollection.hpp here instead of forward declaring GeometryCollection
+#include "GeometryCollection.hpp"
 
 namespace  gf = geofeatures;
 
@@ -37,7 +35,7 @@ namespace  gf = geofeatures;
     /**
      * Initialize this GFGeometryCollection with an internal GeometryCollection implementation.
      */
-    - (instancetype) initWithCPPGeometryCollection: (gf::GeometryCollection) aGeometryCollection;
+    - (instancetype) initWithCPPGeometryCollection: (gf::GeometryCollection<>) aGeometryCollection;
 
 @end
 

--- a/GeoFeatures/Internal/geofeatures/Allocator.hpp
+++ b/GeoFeatures/Internal/geofeatures/Allocator.hpp
@@ -1,0 +1,72 @@
+/**
+*   GeometryCollection.hpp
+*
+*   Copyright 2015 Tony Stone
+*
+*   Licensed under the Apache License, Version 2.0 (the "License");
+*   you may not use this file except in compliance with the License.
+*   You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*   See the License for the specific language governing permissions and
+*   limitations under the License.
+*
+*   Created by Tony Stone on 9/27/15.
+*
+*/
+
+
+#ifndef __GeoFeatures_Allocator_HPP_
+#define __GeoFeatures_Allocator_HPP_
+
+#include <iostream>
+
+namespace geofeatures {
+
+    /**
+     * Simple custom allocator which
+     * will throw an "Objective-C" exception
+     * rather than a C++ exception.
+     */
+    template <typename T>
+    struct Allocator {
+        using value_type = T;
+
+        Allocator() = default;
+        template <class U>
+        Allocator(const Allocator<U>&) {}
+
+        T* allocate(std::size_t n) {
+            if (n <= std::numeric_limits<std::size_t>::max() / sizeof(T)) {
+                if (auto ptr = std::malloc(n * sizeof(T))) {
+                    return static_cast<T*>(ptr);
+                }
+            }
+#ifdef __OBJC__
+            @throw [[NSException alloc] initWithName: NSMallocException reason: @"Could not allocate memory." userInfo: nil];
+#else
+            throw std::bad_alloc();
+#endif
+        }
+        void deallocate(T* ptr, std::size_t n) {
+            std::free(ptr);
+        }
+    };
+
+    template <typename T, typename U>
+    inline bool operator == (const Allocator<T>&, const Allocator<U>&) {
+        return true;
+    }
+
+    template <typename T, typename U>
+    inline bool operator != (const Allocator<T>& a, const Allocator<U>& b) {
+        return !(a == b);
+    }
+
+}   // namespace geofeatures
+
+#endif //__GeoFeatures_Allocator_HPP_

--- a/GeoFeatures/Internal/geofeatures/Collection.hpp
+++ b/GeoFeatures/Internal/geofeatures/Collection.hpp
@@ -1,0 +1,68 @@
+/**
+*   GeometryCollection.hpp
+*
+*   Copyright 2015 Tony Stone
+*
+*   Licensed under the Apache License, Version 2.0 (the "License");
+*   you may not use this file except in compliance with the License.
+*   You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+*   Unless required by applicable law or agreed to in writing, software
+*   distributed under the License is distributed on an "AS IS" BASIS,
+*   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*   See the License for the specific language governing permissions and
+*   limitations under the License.
+*
+*   Created by Tony Stone on 9/27/15.
+*/
+
+
+#ifndef __GeoFeatures_Collection_HPP_
+#define __GeoFeatures_Collection_HPP_
+
+#include "Allocator.hpp"
+
+#include <vector>
+
+namespace geofeatures {
+
+    /**
+    * Base type for Collection classes
+    */
+    template <typename T, typename Allocator = geofeatures::Allocator<T>>
+    class Collection : private std::vector<T, Allocator> {
+
+    public:
+        inline virtual ~Collection() noexcept {}
+
+        using typename std::vector<T, Allocator>::value_type;
+
+        using typename std::vector<T, Allocator>::iterator;
+        using typename std::vector<T, Allocator>::const_iterator;
+
+        using std::vector<T, Allocator>::begin;
+        using std::vector<T, Allocator>::end;
+        using std::vector<T, Allocator>::cbegin;
+        using std::vector<T, Allocator>::cend;
+
+        using std::vector<T, Allocator>::front;
+        using std::vector<T, Allocator>::back;
+
+        using std::vector<T, Allocator>::size;
+        using std::vector<T, Allocator>::empty;
+        using std::vector<T, Allocator>::at;
+        using std::vector<T, Allocator>::operator[];
+
+        using std::vector<T, Allocator>::resize;
+        using std::vector<T, Allocator>::push_back;
+        using std::vector<T, Allocator>::insert;
+        using std::vector<T, Allocator>::erase;
+        using std::vector<T, Allocator>::clear;
+    };
+
+
+}   // namespace geofeatures
+
+#endif //__GeoFeatures_Collection_HPP_

--- a/GeoFeatures/Internal/geofeatures/GeometryCollection.hpp
+++ b/GeoFeatures/Internal/geofeatures/GeometryCollection.hpp
@@ -21,7 +21,7 @@
 *   MODIFIED 2015 BY Tony Stone. Modifications licensed under Apache License, Version 2.0.
 *
 */
-
+#pragma once
 
 #ifndef __GeometryCollection_HPP_
 #define __GeometryCollection_HPP_
@@ -36,57 +36,46 @@
 #include "Polygon.hpp"
 #include "MultiPolygon.hpp"
 
+#include "Collection.hpp"
+#include "Allocator.hpp"
+
 #include <boost/variant.hpp>
 #include <vector>
 
 namespace geofeatures {
 
-        class GeometryCollection;
+    template <typename T, typename Allocator>
+    class GeometryCollection;
+    
+    /**
+    * @class       GeometryCollection
+    *
+    * @brief       A Collection of Geometries.
+    *
+    * @author      Tony Stone
+    * @date        6/9/15
+     *
+    */
+    template <typename T = boost::make_recursive_variant<
+            geofeatures::Point,
+            geofeatures::MultiPoint,
+            geofeatures::Box,
+            geofeatures::LineString,
+            geofeatures::MultiLineString,
+            geofeatures::Ring,
+            geofeatures::Polygon,
+            geofeatures::MultiPolygon,
+            GeometryCollection<boost::recursive_variant_,geofeatures::Allocator<boost::recursive_variant_>>>::type, typename Allocator = geofeatures::Allocator<T>>
+    class GeometryCollection : public Geometry, public Collection <T, Allocator> {
 
-        /**
-        * Variant type of contained objects
-        */
-        typedef boost::variant <
-                        geofeatures::Point,
-                        geofeatures::MultiPoint,
-                        geofeatures::Box,
-                        geofeatures::LineString,
-                        geofeatures::MultiLineString,
-                        geofeatures::Ring,
-                        geofeatures::Polygon,
-                        geofeatures::MultiPolygon,
-                        boost::recursive_wrapper<geofeatures::GeometryCollection>>  GeometryCollectionVariantType;
+    private:
+        typedef Collection <T, Allocator> BaseType;
 
-        /**
-        * Base type for GeometryCollection class
-        */
-        typedef std::vector<GeometryCollectionVariantType> GeometryCollectionBaseType;
-
-        /**
-        * @class       GeometryCollection
-        *
-        * @brief       A Collection of Geometries.
-        *
-        * @author      Tony Stone
-        * @date        6/9/15
-        */
-        class GeometryCollection : public Geometry, public GeometryCollectionBaseType {
-
-        public:
-            inline GeometryCollection() noexcept : Geometry(), GeometryCollectionBaseType() {}
-            inline GeometryCollection(GeometryCollectionBaseType const & other) noexcept : Geometry(), GeometryCollectionBaseType(other) {}
-            inline virtual ~GeometryCollection() noexcept {}
-        };
-
-        /** @defgroup BoostRangeIterators
-        *
-        * @{
-        */
-        inline GeometryCollectionBaseType::iterator range_begin(GeometryCollection& gc) {return gc.begin();}
-        inline GeometryCollectionBaseType::iterator range_end(GeometryCollection& gc) {return gc.end();}
-        inline GeometryCollectionBaseType::const_iterator range_begin(const GeometryCollection& gc) {return gc.begin();}
-        inline GeometryCollectionBaseType::const_iterator range_end(const GeometryCollection& gc) {return gc.end();}
-        /** @} */
+    public:
+        inline GeometryCollection() noexcept : Geometry(), BaseType() {}
+        inline GeometryCollection(const GeometryCollection & other) noexcept : Geometry(), BaseType(other) {}
+        inline virtual ~GeometryCollection() noexcept {}
+    };
 
 }   // namespace geofeatures
 

--- a/GeoFeatures/Internal/geofeatures/GeometryVariant.hpp
+++ b/GeoFeatures/Internal/geofeatures/GeometryVariant.hpp
@@ -50,7 +50,7 @@ namespace geofeatures {
                 geofeatures::Ring,
                 geofeatures::Polygon,
                 geofeatures::MultiPolygon,
-                geofeatures::GeometryCollection>  GeometryVariant;
+                geofeatures::GeometryCollection<>>  GeometryVariant;
 
     typedef boost::variant<
                 geofeatures::Point *,
@@ -61,7 +61,7 @@ namespace geofeatures {
                 geofeatures::Ring *,
                 geofeatures::Polygon *,
                 geofeatures::MultiPolygon *,
-                geofeatures::GeometryCollection *>  GeometryPtrVariant;
+                geofeatures::GeometryCollection<> *>  GeometryPtrVariant;
 
 }   // namespace geofeatures
 

--- a/GeoFeatures/Internal/geofeatures/LineString.hpp
+++ b/GeoFeatures/Internal/geofeatures/LineString.hpp
@@ -28,6 +28,7 @@
 
 #include "Geometry.hpp"
 #include "Point.hpp"
+#include "Collection.hpp"
 
 #include <boost/concept/assert.hpp>
 #include <boost/range.hpp>
@@ -36,14 +37,9 @@
 #include <boost/geometry/core/tags.hpp>
 
 #include <boost/geometry/geometries/concepts/point_concept.hpp>
-#include <vector>
+
 
 namespace geofeatures {
-
-    /**
-    * Base type for LineString class
-    */
-    typedef std::vector<geofeatures::Point> LineStringBaseType;
 
     /**
     * @class       LineString
@@ -53,14 +49,17 @@ namespace geofeatures {
     * @author      Tony Stone
     * @date        6/9/15
     */
-    class LineString : public Geometry, public LineStringBaseType {
+    class LineString : public Geometry, public Collection <geofeatures::Point> {
+
+    private:
+        typedef Collection <geofeatures::Point> BaseType;
 
     public:
-        inline LineString() noexcept : Geometry(), LineStringBaseType() {}
-        LineString(LineString &other) noexcept : Geometry(), LineStringBaseType(other) {}
-        LineString(LineString const &other) noexcept : Geometry(), LineStringBaseType(other) {}
-        LineString(LineStringBaseType &other) noexcept : Geometry(), LineStringBaseType(other) {}
-        LineString(LineStringBaseType const &other) noexcept : Geometry(), LineStringBaseType(other) {}
+        inline LineString() noexcept : Geometry(), BaseType() {}
+        LineString(LineString &other) noexcept : Geometry(), BaseType(other) {}
+        LineString(LineString const &other) noexcept : Geometry(), BaseType(other) {}
+        LineString(BaseType &other) noexcept : Geometry(), BaseType(other) {}
+        LineString(BaseType const &other) noexcept : Geometry(), BaseType(other) {}
 
         inline virtual ~LineString() noexcept {};
     };

--- a/GeoFeatures/Internal/geofeatures/MultiLineString.hpp
+++ b/GeoFeatures/Internal/geofeatures/MultiLineString.hpp
@@ -28,19 +28,15 @@
 
 #include "Geometry.hpp"
 #include "LineString.hpp"
+#include "Collection.hpp"
 
 #include <boost/concept/requires.hpp>
 
 #include <boost/geometry/core/tags.hpp>
 #include <boost/geometry/geometries/concepts/linestring_concept.hpp>
-#include <vector>
+
 
 namespace geofeatures {
-
-    /**
-    * Base type for MultiLineString class
-    */
-    typedef std::vector<geofeatures::LineString> MultiLineStringBaseType;
 
     /**
     * @class       MultiLineString
@@ -50,22 +46,15 @@ namespace geofeatures {
     * @author      Tony Stone
     * @date        6/9/15
     */
-    class MultiLineString : public Geometry, public MultiLineStringBaseType {
+    class MultiLineString : public Geometry, public Collection <geofeatures::LineString> {
+
+    private:
+        typedef Collection <geofeatures::LineString> BaseType;
 
     public:
-        inline MultiLineString () noexcept : Geometry(), MultiLineStringBaseType() {}
+        inline MultiLineString () noexcept : Geometry(), BaseType() {}
         inline virtual ~MultiLineString() noexcept {};
     };
-
-    /** @defgroup BoostRangeIterators
-    *
-    * @{
-    */
-    inline MultiLineStringBaseType::iterator range_begin(MultiLineString& mls) {return mls.begin();}
-    inline MultiLineStringBaseType::iterator range_end(MultiLineString& mls) {return mls.end();}
-    inline MultiLineStringBaseType::const_iterator range_begin(const MultiLineString& mls) {return mls.begin();}
-    inline MultiLineStringBaseType::const_iterator range_end(const MultiLineString& mls) {return mls.end();}
-    /** @} */
 
 }   // namespace geofeatures
 
@@ -82,11 +71,11 @@ namespace geofeatures_boost {
 
         template<>
         struct range_iterator<geofeatures::MultiLineString>
-        { typedef geofeatures::MultiLineStringBaseType::iterator type; };
+        { typedef typename geofeatures::MultiLineString::iterator type; };
 
         template<>
         struct range_const_iterator<geofeatures::MultiLineString>
-        { typedef geofeatures::MultiLineStringBaseType::const_iterator type; };
+        { typedef typename geofeatures::MultiLineString::const_iterator type; };
 
 } // namespace boost
 

--- a/GeoFeatures/Internal/geofeatures/MultiPoint.hpp
+++ b/GeoFeatures/Internal/geofeatures/MultiPoint.hpp
@@ -28,6 +28,7 @@
 
 #include "Geometry.hpp"
 #include "Point.hpp"
+#include "Collection.hpp"
 
 #include <boost/concept/requires.hpp>
 
@@ -43,11 +44,6 @@ namespace geofeatures {
     class Point;
 
     /**
-    * Base type for Ring class
-    */
-    typedef std::vector<geofeatures::Point> MultiPointBaseType;
-
-    /**
     * @class       MultiPoint
     *
     * @brief       A Collection of Points.
@@ -55,22 +51,15 @@ namespace geofeatures {
     * @author      Tony Stone
     * @date        6/9/15
     */
-    class MultiPoint : public Geometry, public MultiPointBaseType {
+    class MultiPoint : public Geometry, public Collection <geofeatures::Point> {
+
+    private:
+        typedef Collection <geofeatures::Point> BaseType;
 
     public:
-        inline MultiPoint() noexcept : Geometry(), MultiPointBaseType() {}
+        inline MultiPoint() noexcept : Geometry(), BaseType() {}
         inline virtual ~MultiPoint() noexcept {};
     };
-
-    /** @defgroup BoostRangeIterators
-    *
-    * @{
-    */
-    inline MultiPointBaseType::iterator range_begin(MultiPoint& mp) {return mp.begin();}
-    inline MultiPointBaseType::iterator range_end(MultiPoint& mp) {return mp.end();}
-    inline MultiPointBaseType::const_iterator range_begin(const MultiPoint& mp) {return mp.begin();}
-    inline MultiPointBaseType::const_iterator range_end(const MultiPoint& mp) {return mp.end();}
-    /** @} */
     
 }   // namespace geofeatures
 
@@ -87,11 +76,11 @@ namespace geofeatures_boost {
 
     template<>
     struct range_iterator<geofeatures::MultiPoint>
-    { typedef geofeatures::MultiPointBaseType::iterator type; };
+    { typedef typename geofeatures::MultiPoint::iterator type; };
 
     template<>
     struct range_const_iterator<geofeatures::MultiPoint>
-    { typedef geofeatures::MultiPointBaseType::const_iterator type; };
+    { typedef typename geofeatures::MultiPoint::const_iterator type; };
 
 } // namespace boost
 

--- a/GeoFeatures/Internal/geofeatures/MultiPolygon.hpp
+++ b/GeoFeatures/Internal/geofeatures/MultiPolygon.hpp
@@ -28,6 +28,7 @@
 
 #include "Geometry.hpp"
 #include "Polygon.hpp"
+#include "Collection.hpp"
 
 #include <boost/geometry/core/access.hpp>
 #include <boost/geometry/core/coordinate_type.hpp>
@@ -40,11 +41,6 @@
 namespace geofeatures {
 
     /**
-    * Base type for MultiPolygon class
-    */
-    typedef std::vector<geofeatures::Polygon> MultiPolygonBaseType;
-
-    /**
     * @class       MultiPolygon
     *
     * @brief       A Collection of Polygons.
@@ -52,25 +48,19 @@ namespace geofeatures {
     * @author      Tony Stone
     * @date        6/9/15
     */
-    class MultiPolygon : public Geometry, public MultiPolygonBaseType {
+    class MultiPolygon : public Geometry, public Collection <geofeatures::Polygon> {
+
+    private:
+        typedef Collection <geofeatures::Polygon> BaseType;
 
     public:
 
-        inline MultiPolygon () noexcept : Geometry(), MultiPolygonBaseType() {}
-        inline MultiPolygon (MultiPolygonBaseType & polygons) noexcept : Geometry(), MultiPolygonBaseType(polygons) {}
+        inline MultiPolygon () noexcept : Geometry(), BaseType() {}
+        inline MultiPolygon (BaseType & polygons) noexcept : Geometry(), BaseType(polygons) {}
 
         inline virtual ~MultiPolygon() {};
     };
 
-    /** @defgroup BoostRangeIterators
-    *
-    * @{
-    */
-    inline MultiPolygonBaseType::iterator range_begin(MultiPolygon& mp) {return mp.begin();}
-    inline MultiPolygonBaseType::iterator range_end(MultiPolygon& mp) {return mp.end();}
-    inline MultiPolygonBaseType::const_iterator range_begin(const MultiPolygon& mp) {return mp.begin();}
-    inline MultiPolygonBaseType::const_iterator range_end(const MultiPolygon& mp) {return mp.end();}
-    /** @} */
 
 }   // namespace geofeatures
 
@@ -87,11 +77,11 @@ namespace geofeatures_boost {
 
     template<>
     struct range_iterator<geofeatures::MultiPolygon>
-    { typedef geofeatures::MultiPolygonBaseType::iterator type; };
+    { typedef typename geofeatures::MultiPolygon::iterator type; };
 
     template<>
     struct range_const_iterator<geofeatures::MultiPolygon>
-    { typedef geofeatures::MultiPolygonBaseType::const_iterator type; };
+    { typedef typename geofeatures::MultiPolygon::const_iterator type; };
 
 } // namespace boost
 

--- a/GeoFeatures/Internal/geofeatures/Ring.hpp
+++ b/GeoFeatures/Internal/geofeatures/Ring.hpp
@@ -28,6 +28,7 @@
 
 #include "Geometry.hpp"
 #include "Point.hpp"
+#include "Collection.hpp"
 
 #include <boost/geometry/core/closure.hpp>
 #include <boost/geometry/core/point_order.hpp>
@@ -40,11 +41,6 @@
 namespace geofeatures {
 
     /**
-    * Base type for Ring class
-    */
-    typedef std::vector<geofeatures::Point> RingBaseType;
-
-    /**
      * @class       Ring
      *
      * @brief       A Ring of Points.
@@ -52,27 +48,20 @@ namespace geofeatures {
      * @author      Tony Stone
      * @date        6/9/15
      */
-    class Ring : public Geometry, public RingBaseType {
+    class Ring : public Geometry, public Collection <geofeatures::Point> {
+
+    private:
+        typedef Collection <geofeatures::Point> BaseType;
 
     public:
-        inline Ring() noexcept : Geometry(), RingBaseType() {}
-        inline Ring(Ring & other) noexcept : Geometry(), RingBaseType(other) {}
-        inline Ring(Ring const & other) noexcept : Geometry(), RingBaseType(other) {}
-        inline Ring(RingBaseType & other) noexcept : Geometry(), RingBaseType(other) {}
-        inline Ring(RingBaseType const & other) noexcept : Geometry(), RingBaseType(other) {}
+        inline Ring() noexcept : Geometry(), BaseType() {}
+        inline Ring(Ring & other) noexcept : Geometry(), BaseType(other) {}
+        inline Ring(Ring const & other) noexcept : Geometry(), BaseType(other) {}
+        inline Ring(BaseType & other) noexcept : Geometry(), BaseType(other) {}
+        inline Ring(BaseType const & other) noexcept : Geometry(), BaseType(other) {}
         
         inline virtual ~Ring() noexcept {};
     };
-
-    /** @defgroup BoostRangeIterators
-    *
-    * @{
-    */
-    inline geofeatures::RingBaseType::iterator range_begin(Ring& r) {return r.begin();}
-    inline geofeatures::RingBaseType::iterator range_end(Ring& r) {return r.end();}
-    inline geofeatures::RingBaseType::const_iterator range_begin(const Ring& r) {return r.begin();}
-    inline geofeatures::RingBaseType::const_iterator range_end(const Ring& r) {return r.end();}
-    /** @} */
     
 }   // namespace geofeatures
 
@@ -99,11 +88,11 @@ namespace geofeatures_boost {
 
     template<>
     struct range_iterator<geofeatures::Ring>
-    { typedef geofeatures::RingBaseType::iterator type; };
+    { typedef typename geofeatures::Ring::iterator type; };
 
     template<>
     struct range_const_iterator<geofeatures::Ring>
-    { typedef geofeatures::RingBaseType::const_iterator type; };
+    { typedef typename geofeatures::Ring::const_iterator type; };
 
 } // namespace boost
 

--- a/GeoFeatures/Internal/geofeatures/io/ReadWKT.hpp
+++ b/GeoFeatures/Internal/geofeatures/io/ReadWKT.hpp
@@ -37,15 +37,15 @@
 namespace geofeatures {
     namespace io {
 
-        template <typename Geometry, typename = typename std::enable_if<std::is_same<Geometry,GeometryCollection>::value>::type>
+        template <typename Geometry, typename = typename std::enable_if<std::is_same<Geometry,GeometryCollection<>>::value>::type>
         inline void readWKT(std::string const &wkt, Geometry &geometryCollection)
         {
             if (!boost::istarts_with(wkt, "GEOMETRYCOLLECTION")) {
                 throw std::invalid_argument("Should start with 'GEOMETRYCOLLECTION'' in (" + wkt + ")");
             }
 
-            GeometryCollectionVariantType (*geometry)(std::string & wkt) =
-                    [](std::string & wkt) -> GeometryCollectionVariantType {
+            GeometryCollection<>::value_type (*geometry)(std::string & wkt) =
+                    [](std::string & wkt) -> GeometryCollection<>::value_type {
 
                         if (boost::istarts_with(wkt, "POINT")) {
                             geofeatures::Point geometry;
@@ -84,7 +84,7 @@ namespace geofeatures {
 
                             return geometry;
                         }
-                        return GeometryCollectionVariantType();
+                        return GeometryCollection<>::value_type();
                     };
 
             std::regex words_regex("\\b(EMPTY|POINT|MULTIPOINT|LINESTRING|MULTILINESTRING|POLYGON)", std::regex_constants::icase);

--- a/GeoFeatures/Internal/geofeatures/io/WriteWKT.hpp
+++ b/GeoFeatures/Internal/geofeatures/io/WriteWKT.hpp
@@ -57,7 +57,7 @@ namespace geofeatures {
 
                         return stringStream.str();
                     }
-                    std::string operator()(const geofeatures::GeometryCollection & v) const {
+                    std::string operator()(const geofeatures::GeometryCollection<> & v) const {
                         
                         std::stringstream stringStream;
                         // TODO: Write to wkt string for GeometryCollection
@@ -72,7 +72,7 @@ namespace geofeatures {
                 friend std::ostream& operator<<(std::ostream& os, const geofeatures::io::wkt<Geometry>& wkt);
             };
 
-            inline std::ostream& operator<<(std::ostream& os, const geofeatures::io::wkt<geofeatures::GeometryCollection>& wkt)
+            inline std::ostream& operator<<(std::ostream& os, const geofeatures::io::wkt<geofeatures::GeometryCollection<>>& wkt)
             {
                 os << "GEOMETRYCOLLECTION";
 
@@ -86,7 +86,7 @@ namespace geofeatures {
                         if (!first) {
                             os << ",";
                         }
-                        os << boost::apply_visitor(geofeatures::io::wkt<geofeatures::GeometryCollection>::variantToString(), *it);
+                        os << boost::apply_visitor(geofeatures::io::wkt<geofeatures::GeometryCollection<>>::variantToString(), *it);
                         first = false;
                     }
                     os << ")";

--- a/GeoFeatures/Internal/geofeatures/operators/AreaOperation.hpp
+++ b/GeoFeatures/Internal/geofeatures/operators/AreaOperation.hpp
@@ -42,7 +42,7 @@ namespace geofeatures {
                 return boost::geometry::area(*v);
             }
 
-            double operator()(const GeometryCollection * v) const {
+            double operator()(const GeometryCollection<> * v) const {
                 return 0.0;
             }
 

--- a/GeoFeatures/Internal/geofeatures/operators/BoundingBoxOperation.hpp
+++ b/GeoFeatures/Internal/geofeatures/operators/BoundingBoxOperation.hpp
@@ -42,7 +42,7 @@ namespace geofeatures {
                 return boost::geometry::return_envelope<geofeatures::Box>(*v);
             }
 
-            geofeatures::Box operator()(const GeometryCollection * v) const {
+            geofeatures::Box operator()(const GeometryCollection<> * v) const {
                 // zero size box
                 return geofeatures::Box(geofeatures::Point(),geofeatures::Point());
             }

--- a/GeoFeatures/Internal/geofeatures/operators/CentroidOperation.hpp
+++ b/GeoFeatures/Internal/geofeatures/operators/CentroidOperation.hpp
@@ -42,7 +42,7 @@ namespace geofeatures {
                 return boost::geometry::return_centroid<Point>(*v);
             }
 
-            Point operator()(const GeometryCollection  * v) const {
+            Point operator()(const GeometryCollection<>  * v) const {
                 return Point();
             }
         };

--- a/GeoFeatures/Internal/geofeatures/operators/IsValidOperation.hpp
+++ b/GeoFeatures/Internal/geofeatures/operators/IsValidOperation.hpp
@@ -42,7 +42,7 @@ namespace geofeatures {
                 return boost::geometry::is_valid(*v);
             }
 
-            bool operator()(const GeometryCollection * v) const {
+            bool operator()(const GeometryCollection<> * v) const {
                 return true;
             }
         };

--- a/GeoFeatures/Internal/geofeatures/operators/LengthOperation.hpp
+++ b/GeoFeatures/Internal/geofeatures/operators/LengthOperation.hpp
@@ -42,7 +42,7 @@ namespace geofeatures {
                 return boost::geometry::length(*v);
             }
 
-            double operator()(const GeometryCollection * v) const {
+            double operator()(const GeometryCollection<> * v) const {
                 return 0.0;
             }
         };

--- a/GeoFeatures/Internal/geofeatures/operators/PerimeterOperation.hpp
+++ b/GeoFeatures/Internal/geofeatures/operators/PerimeterOperation.hpp
@@ -42,7 +42,7 @@ namespace geofeatures {
                 return boost::geometry::perimeter(*v);
             }
 
-            double operator()(const GeometryCollection * v) const {
+            double operator()(const GeometryCollection<> * v) const {
                 return 0.0;
             }
         };

--- a/GeoFeatures/Internal/geofeatures/operators/UnionOperation.hpp
+++ b/GeoFeatures/Internal/geofeatures/operators/UnionOperation.hpp
@@ -94,7 +94,7 @@ namespace geofeatures {
                     return tmp.front();
                 }
 
-                GeometryCollection output;
+                GeometryCollection<> output;
                 for (auto it = tmp.begin(); it != tmp.end(); ++it) {
                     output.push_back(*it);
                 }
@@ -105,23 +105,23 @@ namespace geofeatures {
             // For GeometryCollections the initial implemention of these
             // is a simple combination of the right and left hand sides.
             //
-            GeometryVariant operator()( const GeometryCollection * lhs, const GeometryCollection * rhs) const {
-                GeometryCollection output(*lhs);
+            GeometryVariant operator()( const GeometryCollection<> * lhs, const GeometryCollection<> * rhs) const {
+                GeometryCollection<> output(*lhs);
 
-                std::for_each(rhs->begin(), rhs->end(), [&output](const GeometryCollectionVariantType & item) {
+                std::for_each(rhs->begin(), rhs->end(), [&output](const GeometryCollection<>::value_type & item) {
                                   output.push_back(item);
                               });
                 return output;
             }
 
             template <typename T>
-            GeometryVariant operator()( const T * lhs, const GeometryCollection * rhs) const {
+            GeometryVariant operator()( const T * lhs, const GeometryCollection<> * rhs) const {
                 return this->operator()(rhs, lhs);  // Reverse order and chain to reverse order method
             }
 
             template <typename T>
-            GeometryVariant operator()( const GeometryCollection * lhs, const T * rhs) const {
-                GeometryCollection output(*lhs);
+            GeometryVariant operator()( const GeometryCollection<> * lhs, const T * rhs) const {
+                GeometryCollection<> output(*lhs);
 
                 output.push_back(*rhs);
 
@@ -130,7 +130,7 @@ namespace geofeatures {
 
             template <typename T, typename U>
             GeometryVariant operator()( const T * lhs, const U * rhs) const {
-                GeometryCollection collection;
+                GeometryCollection<> collection;
 
                 collection.push_back(*lhs);
                 collection.push_back(*rhs);

--- a/GeoFeatures/Internal/geofeatures/operators/WKTOperation.hpp
+++ b/GeoFeatures/Internal/geofeatures/operators/WKTOperation.hpp
@@ -44,10 +44,10 @@ namespace geofeatures {
                 return stringStream.str();
             }
 
-            std::string operator()(const GeometryCollection * v) const {
+            std::string operator()(const GeometryCollection<> * v) const {
 
                 std::stringstream stringStream;
-                stringStream << io::wkt<GeometryCollection>(*v);
+                stringStream << io::wkt<GeometryCollection<>>(*v);
 
                 return stringStream.str();
             }

--- a/GeoFeatures/Internal/geofeatures/operators/WithinOperation.hpp
+++ b/GeoFeatures/Internal/geofeatures/operators/WithinOperation.hpp
@@ -43,7 +43,7 @@ namespace geofeatures {
                 return boost::geometry::within(*lhs, *rhs);
             }
 
-            bool operator()(const Point * lhs, const GeometryCollection * rhs) const {
+            bool operator()(const Point * lhs, const GeometryCollection<> * rhs) const {
                 return false;
             }
 


### PR DESCRIPTION
- Added a custom Allocator for use with all collection classes to throw an Objective-C exception on Out of Memory.
- Created a Collection base class (with out new Allocator as the default allocator) that all collection types are inherited from.
- Corrected the issue with subclassing std::vector.  Made std::vector private and exposed it's methods with "using" statements.
- Restructured GeometryCollection, LineString, Ring, MultiLineString, MultiPoint, and MultiPolygon to use the Collection base class.
- Removed unneeded range_beign, range_end free functions from multi classes.
- Updated all classes to work the new new template GeometryCollection class.
