### PR TITLE
Set object at indexed subscript

### DIFF
--- a/Example/Tests/Model/GFMutableGeometryCollectionTests.m
+++ b/Example/Tests/Model/GFMutableGeometryCollectionTests.m
@@ -141,5 +141,61 @@
     }
 
 
+#pragma mark - Indexed Subscripting Tests
+
+    - (void) testSetObjectAtIndexedSubscript_WithValidPolygonAndValidIndex {
+
+        GFMutableGeometryCollection * geometryCollection = [[GFMutableGeometryCollection alloc] init];
+
+        geometryCollection[0] = [[GFPolygon alloc] initWithWKT: @"POLYGON((20 0,20 10,40 10,40 0,20 0))"];
+
+        XCTAssertEqualObjects([geometryCollection toWKTString], @"GEOMETRYCOLLECTION(POLYGON((20 0,20 10,40 10,40 0,20 0)))");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_With3ValidPolygonsAndValidIndex {
+
+        GFMutableGeometryCollection * geometryCollection = [[GFMutableGeometryCollection alloc] init];
+
+        geometryCollection[0] = [[GFPolygon alloc] initWithWKT: @"POLYGON((20 0,20 10,40 10,40 0,20 0))"];
+        geometryCollection[1] = [[GFPolygon alloc] initWithWKT: @"POLYGON((5 5,5 8,8 8,8 5,5 5))"];
+        geometryCollection[2] = [[GFPolygon alloc] initWithWKT: @"POLYGON((4 4,4 7,7 7,7 4,4 4))"];
+
+        XCTAssertEqualObjects([geometryCollection toWKTString], @"GEOMETRYCOLLECTION(POLYGON((20 0,20 10,40 10,40 0,20 0)),POLYGON((5 5,5 8,8 8,8 5,5 5)),POLYGON((4 4,4 7,7 7,7 4,4 4)))");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithReassignValidPolygonAndValidIndex {
+
+        GFMutableGeometryCollection * geometryCollection = [[GFMutableGeometryCollection alloc] init];
+
+        geometryCollection[0] = [[GFPolygon alloc] initWithWKT: @"POLYGON((4 4,4 7,7 7,7 4,4 4))"];
+        geometryCollection[1] = [[GFPolygon alloc] initWithWKT: @"POLYGON((5 5,5 8,8 8,8 5,5 5))"];
+
+        geometryCollection[0] = [[GFPolygon alloc] initWithWKT: @"POLYGON((20 0,20 10,40 10,40 0,20 0))"];
+
+        XCTAssertEqualObjects([geometryCollection toWKTString], @"GEOMETRYCOLLECTION(POLYGON((20 0,20 10,40 10,40 0,20 0)),POLYGON((5 5,5 8,8 8,8 5,5 5)))");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithNilPolygonAndValidIndex {
+
+        GFMutableGeometryCollection * geometryCollection = [[GFMutableGeometryCollection alloc] init];
+
+        XCTAssertThrowsSpecificNamed((geometryCollection[0] = nil), NSException, NSInvalidArgumentException);
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithInvalidObjectTypeAndValidIndex {
+
+        GFMutableGeometryCollection * geometryCollection = [[GFMutableGeometryCollection alloc] init];
+
+        XCTAssertThrowsSpecificNamed((geometryCollection[0] = [[NSObject alloc] init]), NSException, NSInvalidArgumentException);
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithValidPolygonAndInvalidIndex {
+
+        GFMutableGeometryCollection * geometryCollection = [[GFMutableGeometryCollection alloc] init];
+
+        XCTAssertThrowsSpecificNamed((geometryCollection[1] = [[GFPolygon alloc] init]), NSException, NSRangeException);
+    }
+
+
 @end
 

--- a/Example/Tests/Model/GFMutableGeometryCollectionTests.m
+++ b/Example/Tests/Model/GFMutableGeometryCollectionTests.m
@@ -157,10 +157,11 @@
         GFMutableGeometryCollection * geometryCollection = [[GFMutableGeometryCollection alloc] init];
 
         geometryCollection[0] = [[GFPolygon alloc] initWithWKT: @"POLYGON((20 0,20 10,40 10,40 0,20 0))"];
-        geometryCollection[1] = [[GFPolygon alloc] initWithWKT: @"POLYGON((5 5,5 8,8 8,8 5,5 5))"];
-        geometryCollection[2] = [[GFPolygon alloc] initWithWKT: @"POLYGON((4 4,4 7,7 7,7 4,4 4))"];
+        geometryCollection[1] = [[GFPoint alloc] initWithWKT: @"POINT(103 2)"];
+        geometryCollection[2] = [[GFBox alloc] initWithWKT: @"BOX(1 1,3 3)"];
+        geometryCollection[3] = [[GFLineString alloc] initWithWKT: @"LINESTRING(5 0,10 0,5 -5,5 0)"];
 
-        XCTAssertEqualObjects([geometryCollection toWKTString], @"GEOMETRYCOLLECTION(POLYGON((20 0,20 10,40 10,40 0,20 0)),POLYGON((5 5,5 8,8 8,8 5,5 5)),POLYGON((4 4,4 7,7 7,7 4,4 4)))");
+        XCTAssertEqualObjects([geometryCollection toWKTString], @"GEOMETRYCOLLECTION(POLYGON((20 0,20 10,40 10,40 0,20 0)),POINT(103 2),POLYGON((1 1,1 3,3 3,3 1,1 1)),LINESTRING(5 0,10 0,5 -5,5 0))");
     }
 
     - (void) testSetObjectAtIndexedSubscript_WithReassignValidPolygonAndValidIndex {

--- a/Example/Tests/Model/GFMutableLineStringTests.m
+++ b/Example/Tests/Model/GFMutableLineStringTests.m
@@ -128,6 +128,53 @@
         XCTAssertThrowsSpecificNamed([lineString removePointAtIndex: 1], NSException, NSRangeException);
     }
 
+#pragma mark - Indexed Subscripting Tests
+
+    - (void) testSetObjectAtIndexedSubscript_WithValidPointAndValidIndex {
+
+        GFMutableLineString * multiPoint = [[GFMutableLineString alloc] init];
+
+        multiPoint[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
+
+        XCTAssertEqualObjects([multiPoint toWKTString], @"LINESTRING(1 1)");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_With3ValidPointAndValidIndex {
+
+        GFMutableLineString * multiPoint = [[GFMutableLineString alloc] init];
+
+        multiPoint[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
+        multiPoint[1] = [[GFPoint alloc] initWithWKT: @"POINT(2 2)"];
+        multiPoint[2] = [[GFPoint alloc] initWithWKT: @"POINT(3 3)"];
+
+        XCTAssertEqualObjects([multiPoint toWKTString], @"LINESTRING(1 1,2 2,3 3)");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithReassignValidPointAndValidIndex {
+
+        GFMutableLineString * multiPoint = [[GFMutableLineString alloc] init];
+
+        multiPoint[0] = [[GFPoint alloc] initWithWKT: @"POINT(3 3)"];
+        multiPoint[1] = [[GFPoint alloc] initWithWKT: @"POINT(2 2)"];
+
+        multiPoint[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
+
+        XCTAssertEqualObjects([multiPoint toWKTString], @"LINESTRING(1 1,2 2)");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithNilPointAndValidIndex {
+
+        GFMutableLineString * multiPoint = [[GFMutableLineString alloc] init];
+
+        XCTAssertThrowsSpecificNamed((multiPoint[0] = nil), NSException, NSInvalidArgumentException);
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithValidPointAndInvalidIndex {
+
+        GFMutableLineString * multiPoint = [[GFMutableLineString alloc] init];
+
+        XCTAssertThrowsSpecificNamed((multiPoint[1] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"]), NSException, NSRangeException);
+    }
 
 @end
 

--- a/Example/Tests/Model/GFMutableLineStringTests.m
+++ b/Example/Tests/Model/GFMutableLineStringTests.m
@@ -132,48 +132,48 @@
 
     - (void) testSetObjectAtIndexedSubscript_WithValidPointAndValidIndex {
 
-        GFMutableLineString * multiPoint = [[GFMutableLineString alloc] init];
+        GFMutableLineString * lineString = [[GFMutableLineString alloc] init];
 
-        multiPoint[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
+        lineString[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
 
-        XCTAssertEqualObjects([multiPoint toWKTString], @"LINESTRING(1 1)");
+        XCTAssertEqualObjects([lineString toWKTString], @"LINESTRING(1 1)");
     }
 
     - (void) testSetObjectAtIndexedSubscript_With3ValidPointAndValidIndex {
 
-        GFMutableLineString * multiPoint = [[GFMutableLineString alloc] init];
+        GFMutableLineString * lineString = [[GFMutableLineString alloc] init];
 
-        multiPoint[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
-        multiPoint[1] = [[GFPoint alloc] initWithWKT: @"POINT(2 2)"];
-        multiPoint[2] = [[GFPoint alloc] initWithWKT: @"POINT(3 3)"];
+        lineString[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
+        lineString[1] = [[GFPoint alloc] initWithWKT: @"POINT(2 2)"];
+        lineString[2] = [[GFPoint alloc] initWithWKT: @"POINT(3 3)"];
 
-        XCTAssertEqualObjects([multiPoint toWKTString], @"LINESTRING(1 1,2 2,3 3)");
+        XCTAssertEqualObjects([lineString toWKTString], @"LINESTRING(1 1,2 2,3 3)");
     }
 
     - (void) testSetObjectAtIndexedSubscript_WithReassignValidPointAndValidIndex {
 
-        GFMutableLineString * multiPoint = [[GFMutableLineString alloc] init];
+        GFMutableLineString * lineString = [[GFMutableLineString alloc] init];
 
-        multiPoint[0] = [[GFPoint alloc] initWithWKT: @"POINT(3 3)"];
-        multiPoint[1] = [[GFPoint alloc] initWithWKT: @"POINT(2 2)"];
+        lineString[0] = [[GFPoint alloc] initWithWKT: @"POINT(3 3)"];
+        lineString[1] = [[GFPoint alloc] initWithWKT: @"POINT(2 2)"];
 
-        multiPoint[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
+        lineString[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
 
-        XCTAssertEqualObjects([multiPoint toWKTString], @"LINESTRING(1 1,2 2)");
+        XCTAssertEqualObjects([lineString toWKTString], @"LINESTRING(1 1,2 2)");
     }
 
     - (void) testSetObjectAtIndexedSubscript_WithNilPointAndValidIndex {
 
-        GFMutableLineString * multiPoint = [[GFMutableLineString alloc] init];
+        GFMutableLineString * lineString = [[GFMutableLineString alloc] init];
 
-        XCTAssertThrowsSpecificNamed((multiPoint[0] = nil), NSException, NSInvalidArgumentException);
+        XCTAssertThrowsSpecificNamed((lineString[0] = nil), NSException, NSInvalidArgumentException);
     }
 
     - (void) testSetObjectAtIndexedSubscript_WithValidPointAndInvalidIndex {
 
-        GFMutableLineString * multiPoint = [[GFMutableLineString alloc] init];
+        GFMutableLineString * lineString = [[GFMutableLineString alloc] init];
 
-        XCTAssertThrowsSpecificNamed((multiPoint[1] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"]), NSException, NSRangeException);
+        XCTAssertThrowsSpecificNamed((lineString[1] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"]), NSException, NSRangeException);
     }
 
 @end

--- a/Example/Tests/Model/GFMutableMultiLineStringTests.m
+++ b/Example/Tests/Model/GFMutableMultiLineStringTests.m
@@ -128,6 +128,53 @@
         XCTAssertThrowsSpecificNamed([multiLineString removeGeometryAtIndex: 1], NSException, NSRangeException);
     }
 
+#pragma mark - Indexed Subscripting Tests
+
+    - (void) testSetObjectAtIndexedSubscript_WithValidLineStringAndValidIndex {
+
+        GFMutableMultiLineString * multiLineString = [[GFMutableMultiLineString alloc] init];
+
+        multiLineString[0] = [[GFLineString alloc] initWithWKT: @"LINESTRING(0 0,5 0)"];
+
+        XCTAssertEqualObjects([multiLineString toWKTString], @"MULTILINESTRING((0 0,5 0))");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_With3ValidLineStringsAndValidIndex {
+
+        GFMutableMultiLineString * multiLineString = [[GFMutableMultiLineString alloc] init];
+
+        multiLineString[0] = [[GFLineString alloc] initWithWKT: @"LINESTRING(0 0,5 0)"];
+        multiLineString[1] = [[GFLineString alloc] initWithWKT: @"LINESTRING(5 0,10 0,5 -5,5 0)"];
+        multiLineString[2] = [[GFLineString alloc] initWithWKT: @"LINESTRING(1 1,2 2,3 3)"];
+
+        XCTAssertEqualObjects([multiLineString toWKTString], @"MULTILINESTRING((0 0,5 0),(5 0,10 0,5 -5,5 0),(1 1,2 2,3 3))");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithReassignValidLineStringAndValidIndex {
+
+        GFMutableMultiLineString * multiLineString = [[GFMutableMultiLineString alloc] init];
+
+        multiLineString[0] = [[GFLineString alloc] initWithWKT: @"LINESTRING(1 1,2 2,3 3)"];
+        multiLineString[1] = [[GFLineString alloc] initWithWKT: @"LINESTRING(5 0,10 0,5 -5,5 0)"];
+
+        multiLineString[0] = [[GFLineString alloc] initWithWKT: @"LINESTRING(0 0,5 0)"];
+
+        XCTAssertEqualObjects([multiLineString toWKTString], @"MULTILINESTRING((0 0,5 0),(5 0,10 0,5 -5,5 0))");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithNilLineStringAndValidIndex {
+
+        GFMutableMultiLineString * multiLineString = [[GFMutableMultiLineString alloc] init];
+
+        XCTAssertThrowsSpecificNamed((multiLineString[0] = nil), NSException, NSInvalidArgumentException);
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithValidLineStringAndInvalidIndex {
+
+        GFMutableMultiLineString * multiLineString = [[GFMutableMultiLineString alloc] init];
+
+        XCTAssertThrowsSpecificNamed((multiLineString[1] = [[GFLineString alloc] init]), NSException, NSRangeException);
+    }
 
 @end
 

--- a/Example/Tests/Model/GFMutableMultiPointTests.m
+++ b/Example/Tests/Model/GFMutableMultiPointTests.m
@@ -128,6 +128,53 @@
         XCTAssertThrowsSpecificNamed([multiPoint removeGeometryAtIndex: 1], NSException, NSRangeException);
     }
 
+#pragma mark - Indexed Subscripting Tests
+
+    - (void) testSetObjectAtIndexedSubscript_WithValidPointAndValidIndex {
+
+        GFMutableMultiPoint * multiPoint = [[GFMutableMultiPoint alloc] init];
+
+        multiPoint[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
+
+        XCTAssertEqualObjects([multiPoint toWKTString], @"MULTIPOINT((1 1))");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_With3ValidPointAndValidIndex {
+
+        GFMutableMultiPoint * multiPoint = [[GFMutableMultiPoint alloc] init];
+
+        multiPoint[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
+        multiPoint[1] = [[GFPoint alloc] initWithWKT: @"POINT(2 2)"];
+        multiPoint[2] = [[GFPoint alloc] initWithWKT: @"POINT(3 3)"];
+
+        XCTAssertEqualObjects([multiPoint toWKTString], @"MULTIPOINT((1 1),(2 2),(3 3))");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithReassignValidPointAndValidIndex {
+
+        GFMutableMultiPoint * multiPoint = [[GFMutableMultiPoint alloc] init];
+
+        multiPoint[0] = [[GFPoint alloc] initWithWKT: @"POINT(3 3)"];
+        multiPoint[1] = [[GFPoint alloc] initWithWKT: @"POINT(2 2)"];
+
+        multiPoint[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
+
+        XCTAssertEqualObjects([multiPoint toWKTString], @"MULTIPOINT((1 1),(2 2))");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithNilPointAndValidIndex {
+
+        GFMutableMultiPoint * multiPoint = [[GFMutableMultiPoint alloc] init];
+
+        XCTAssertThrowsSpecificNamed((multiPoint[0] = nil), NSException, NSInvalidArgumentException);
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithValidPointAndInvalidIndex {
+
+        GFMutableMultiPoint * multiPoint = [[GFMutableMultiPoint alloc] init];
+
+        XCTAssertThrowsSpecificNamed((multiPoint[1] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"]), NSException, NSRangeException);
+    }
 
 @end
 

--- a/Example/Tests/Model/GFMutableMultiPolygonTests.m
+++ b/Example/Tests/Model/GFMutableMultiPolygonTests.m
@@ -128,6 +128,55 @@
         XCTAssertThrowsSpecificNamed([multiPolygon removeGeometryAtIndex: 1], NSException, NSRangeException);
     }
 
+#pragma mark - Indexed Subscripting Tests
+
+    - (void) testSetObjectAtIndexedSubscript_WithValidPolygonAndValidIndex {
+
+        GFMutableMultiPolygon * multiPolygon = [[GFMutableMultiPolygon alloc] init];
+
+        multiPolygon[0] = [[GFPolygon alloc] initWithWKT: @"POLYGON((20 0,20 10,40 10,40 0,20 0))"];
+
+        XCTAssertEqualObjects([multiPolygon toWKTString], @"MULTIPOLYGON(((20 0,20 10,40 10,40 0,20 0)))");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_With3ValidPolygonsAndValidIndex {
+
+        GFMutableMultiPolygon * multiPolygon = [[GFMutableMultiPolygon alloc] init];
+
+        multiPolygon[0] = [[GFPolygon alloc] initWithWKT: @"POLYGON((20 0,20 10,40 10,40 0,20 0))"];
+        multiPolygon[1] = [[GFPolygon alloc] initWithWKT: @"POLYGON((5 5,5 8,8 8,8 5,5 5))"];
+        multiPolygon[2] = [[GFPolygon alloc] initWithWKT: @"POLYGON((4 4,4 7,7 7,7 4,4 4))"];
+
+        XCTAssertEqualObjects([multiPolygon toWKTString], @"MULTIPOLYGON(((20 0,20 10,40 10,40 0,20 0)),((5 5,5 8,8 8,8 5,5 5)),((4 4,4 7,7 7,7 4,4 4)))");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithReassignValidPolygonAndValidIndex {
+
+        GFMutableMultiPolygon * multiPolygon = [[GFMutableMultiPolygon alloc] init];
+
+        multiPolygon[0] = [[GFPolygon alloc] initWithWKT: @"POLYGON((4 4,4 7,7 7,7 4,4 4))"];
+        multiPolygon[1] = [[GFPolygon alloc] initWithWKT: @"POLYGON((5 5,5 8,8 8,8 5,5 5))"];
+
+        multiPolygon[0] = [[GFPolygon alloc] initWithWKT: @"POLYGON((20 0,20 10,40 10,40 0,20 0))"];
+
+        XCTAssertEqualObjects([multiPolygon toWKTString], @"MULTIPOLYGON(((20 0,20 10,40 10,40 0,20 0)),((5 5,5 8,8 8,8 5,5 5)))");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithNilPolygonAndValidIndex {
+
+        GFMutableMultiPolygon * multiPolygon = [[GFMutableMultiPolygon alloc] init];
+
+        XCTAssertThrowsSpecificNamed((multiPolygon[0] = nil), NSException, NSInvalidArgumentException);
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithValidPolygonAndInvalidIndex {
+
+        GFMutableMultiPolygon * multiPolygon = [[GFMutableMultiPolygon alloc] init];
+
+        XCTAssertThrowsSpecificNamed((multiPolygon[1] = [[GFPolygon alloc] init]), NSException, NSRangeException);
+    }
+
+
 
 @end
 

--- a/Example/Tests/Model/GFMutableRingTests.m
+++ b/Example/Tests/Model/GFMutableRingTests.m
@@ -148,6 +148,55 @@
         XCTAssertThrowsSpecificNamed([ring removePointAtIndex: 1], NSException, NSRangeException);
     }
 
+#pragma mark - Indexed Subscripting Tests
+
+    - (void) testSetObjectAtIndexedSubscript_WithValidPointAndValidIndex {
+
+        GFMutableRing * ring = [[GFMutableRing alloc] init];
+
+        ring[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
+
+        XCTAssertEqualObjects([ring toWKTString], @"LINESTRING(1 1)");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_With5ValidPointAndValidIndex {
+
+        GFMutableRing * ring = [[GFMutableRing alloc] init];
+
+        ring[0] = [[GFPoint alloc] initWithWKT: @"POINT(20 0)"];
+        ring[1] = [[GFPoint alloc] initWithWKT: @"POINT(20 10)"];
+        ring[2] = [[GFPoint alloc] initWithWKT: @"POINT(40 10)"];
+        ring[3] = [[GFPoint alloc] initWithWKT: @"POINT(40 0)"];
+        ring[4] = [[GFPoint alloc] initWithWKT: @"POINT(20 0)"];
+
+        XCTAssertEqualObjects([ring toWKTString], @"LINESTRING(20 0,20 10,40 10,40 0,20 0)");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithReassignValidPointAndValidIndex {
+
+        GFMutableRing * ring = [[GFMutableRing alloc] init];
+
+        ring[0] = [[GFPoint alloc] initWithWKT: @"POINT(3 3)"];
+        ring[1] = [[GFPoint alloc] initWithWKT: @"POINT(2 2)"];
+
+        ring[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
+
+        XCTAssertEqualObjects([ring toWKTString], @"LINESTRING(1 1,2 2)");
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithNilPointAndValidIndex {
+
+        GFMutableRing * ring = [[GFMutableRing alloc] init];
+
+        XCTAssertThrowsSpecificNamed((ring[0] = nil), NSException, NSInvalidArgumentException);
+    }
+
+    - (void) testSetObjectAtIndexedSubscript_WithValidPointAndInvalidIndex {
+
+        GFMutableRing * ring = [[GFMutableRing alloc] init];
+
+        XCTAssertThrowsSpecificNamed((ring[1] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"]), NSException, NSRangeException);
+    }
 
 @end
 

--- a/GeoFeatures/GFGeometryCollection.h
+++ b/GeoFeatures/GFGeometryCollection.h
@@ -151,4 +151,26 @@
      */
     - (void) removeGeometryAtIndex: (NSUInteger) index;
 
+    /** Sets the GFGeometry at the given index.
+     *
+     * @param aGeometry The GFGeometry with which to replace the GFGeometry at index in the GFMutableGeometryCollection. This value must not be nil.
+     * @param index  The index of the GFGeometry to be replaced. This value must not exceed the bounds of the GFMutableGeometryCollection.
+     *
+     * Example:
+     *
+     * @code
+     * {
+     *    GFMutableGeometryCollection * geometryCollection = [[GFMutableGeometryCollection alloc] init];
+     *
+     *    geometryCollection[0] = [[GFPolygon alloc] initWithWKT: @"POLYGON((0 0,0 90,90 90,90 0,0 0))"];
+     *    geometryCollection[1] = [[GFLineString alloc] initWithWKT: @"LINESTRING(1 1,2 2,3 3)"];
+     * }
+     * @endcode
+     *
+     * @throws NSException If index is beyond the end of the collection (that is, if index is greater than or equal to the value returned by count), an NSRangeException is raised.
+     *
+     * @since 1.3.0
+     */
+    - (void) setObject: (id) aGeometry atIndexedSubscript:(NSUInteger) index;
+
 @end

--- a/GeoFeatures/GFGeometryCollection.mm
+++ b/GeoFeatures/GFGeometryCollection.mm
@@ -218,4 +218,25 @@ namespace gf = geofeatures;
         _geometryCollection.erase(_geometryCollection.begin() + index);
     }
 
+    - (void) setObject: (id) aGeometry atIndexedSubscript: (NSUInteger) index {
+
+        if (aGeometry == nil) {
+            [NSException raise: NSInvalidArgumentException format: @"aGeometry can not be nil."];
+        }
+        if (index > _geometryCollection.size()) {
+            [NSException raise: NSRangeException format: @"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _geometryCollection.size()];
+        }
+        if (![aGeometry isKindOfClass: [GFGeometry class]]) {
+            [NSException raise: NSInvalidArgumentException format: @"Invalid class, aGeometry must be of type GFGeometry or a subclass of GFGeometry."];
+        }
+        // Note: geofeatures::<collection type> classes will throw an "Objective-C"
+        // NSMallocException if they fail to allocate memory for the operation below
+        // so no C++ exception block is required.
+        if (index == _geometryCollection.size()) {
+            _geometryCollection.push_back([aGeometry cppGeometryVariant]);
+        } else {
+            _geometryCollection[index] = [aGeometry cppGeometryVariant];
+        }
+    }
+
 @end

--- a/GeoFeatures/GFLineString.h
+++ b/GeoFeatures/GFLineString.h
@@ -182,4 +182,26 @@
      */
     - (void) removePointAtIndex: (NSUInteger) index;
 
+    /** Sets the GFPoint at the given index.
+     *
+     * @param aPoint The GFPoint with which to replace the GFPoint at index in the GFMutableLineString. This value must not be nil.
+     * @param index  The index of the GFPoint to be replaced. This value must not exceed the bounds of the GFMutableLineString.
+     *
+     * Example:
+     *
+     * @code
+     * {
+     *    GFMutableLineString * lineString = [[GFMutableLineString alloc] init];
+     *
+     *    lineString[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
+     *    lineString[1] = [[GFPoint alloc] initWithWKT: @"POINT(2 2)"];
+     * }
+     * @endcode
+     *
+     * @throws NSException If index is beyond the end of the collection (that is, if index is greater than or equal to the value returned by count), an NSRangeException is raised.
+     *
+     * @since 1.3.0
+     */
+    - (void) setObject: (GFPoint *) aPoint atIndexedSubscript:(NSUInteger) index;
+
 @end

--- a/GeoFeatures/GFLineString.mm
+++ b/GeoFeatures/GFLineString.mm
@@ -215,5 +215,23 @@ namespace gf = geofeatures;
         _lineString.erase(_lineString.begin() + index);
     }
 
+    - (void) setObject: (GFPoint *) aPoint atIndexedSubscript: (NSUInteger) index {
+
+        if (aPoint == nil) {
+            [NSException raise: NSInvalidArgumentException format: @"aPoint can not be nil."];
+        }
+        if (index > _lineString.size()) {
+            [NSException raise: NSRangeException format: @"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _lineString.size()];
+        }
+        // Note: geofeatures::<collection type> classes will throw an "Objective-C"
+        // NSMallocException if they fail to allocate memory for the operation below
+        // so no C++ exception block is required.
+        if (index == _lineString.size()) {
+            _lineString.push_back([aPoint cppConstPointReference]);
+        } else {
+            _lineString[index] = [aPoint cppConstPointReference];
+        }
+    }
+
 @end
 

--- a/GeoFeatures/GFMultiLineString.h
+++ b/GeoFeatures/GFMultiLineString.h
@@ -190,7 +190,7 @@
 
     /** Sets the GFLineString at the given index.
      *
-     * @param aLineString The GFLineString with which to replace the GFLineString at index index in the GFMutableMultiLineString. This value must not be nil.
+     * @param aLineString The GFLineString with which to replace the GFLineString at index in the GFMutableMultiLineString. This value must not be nil.
      * @param index  The index of the GFLineString to be replaced. This value must not exceed the bounds of the GFMutableMultiLineString.
      *
      * Example:

--- a/GeoFeatures/GFMultiLineString.h
+++ b/GeoFeatures/GFMultiLineString.h
@@ -188,5 +188,27 @@
      */
     - (void) removeGeometryAtIndex: (NSUInteger) index;
 
+    /** Sets the GFLineString at the given index.
+     *
+     * @param aLineString The GFLineString with which to replace the GFLineString at index index in the GFMutableMultiLineString. This value must not be nil.
+     * @param index  The index of the GFLineString to be replaced. This value must not exceed the bounds of the GFMutableMultiLineString.
+     *
+     * Example:
+     *
+     * @code
+     * {
+     *    GFMutableMultiLineString * multiLineString = [[GFMutableMultiLineString alloc] init];
+     *
+     *    multiLineString[0] = [[GFLineString alloc] initWithWKT: @"LINESTRING(1 1,2 2,3 3)"];
+     *    multiLineString[1] = [[GFLineString alloc] initWithWKT: @"LINESTRING(2 2,103 1)"];
+     * }
+     * @endcode
+     *
+     * @throws NSException If index is beyond the end of the collection (that is, if index is greater than or equal to the value returned by count), an NSRangeException is raised.
+     *
+     * @since 1.3.0
+     */
+    - (void) setObject: (GFLineString *) aLineString atIndexedSubscript:(NSUInteger) index;
+
 @end
 

--- a/GeoFeatures/GFMultiLineString.mm
+++ b/GeoFeatures/GFMultiLineString.mm
@@ -234,4 +234,22 @@ namespace gf = geofeatures;
         _multiLineString.erase(_multiLineString.begin() + index);
     }
 
+    - (void) setObject: (GFLineString *) aLineString atIndexedSubscript: (NSUInteger) index {
+
+        if (aLineString == nil) {
+            [NSException raise: NSInvalidArgumentException format: @"aLineString can not be nil."];
+        }
+        if (index > _multiLineString.size()) {
+            [NSException raise: NSRangeException format: @"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _multiLineString.size()];
+        }
+        // Note: geofeatures::<collection type> classes will throw an "Objective-C"
+        // NSMallocException if they fail to allocate memory for the operation below
+        // so no C++ exception block is required.
+        if (index == _multiLineString.size()) {
+            _multiLineString.push_back([aLineString cppConstLineStringReference]);
+        } else {
+            _multiLineString[index] = [aLineString cppConstLineStringReference];
+        }
+    }
+
 @end

--- a/GeoFeatures/GFMultiPoint.h
+++ b/GeoFeatures/GFMultiPoint.h
@@ -182,4 +182,26 @@
      */
     - (void) removeGeometryAtIndex: (NSUInteger) index;
 
+    /** Sets the GFPoint at the given index.
+     *
+     * @param aPoint The GFPoint with which to replace the GFPoint at index index in the GFMutableMultiPoint. This value must not be nil.
+     * @param index  The index of the GFPoint to be replaced. This value must not exceed the bounds of the GFMutableMultiPoint.
+     *
+     * Example:
+     *
+     * @code
+     * {
+     *    GFMutableMultiPoint * multiPoint = [[GFMutableMultiPoint alloc] init];
+     *
+     *    multiPoint[0] = [[GFPoint alloc] initWithWKT: @"POINT(1 1)"];
+     *    multiPoint[1] = [[GFPoint alloc] initWithWKT: @"POINT(2 2)"];
+     * }
+     * @endcode
+     *
+     * @throws NSException If index is beyond the end of the collection (that is, if index is greater than or equal to the value returned by count), an NSRangeException is raised.
+     *
+     * @since 1.3.0
+     */
+    - (void) setObject: (GFPoint *) aPoint atIndexedSubscript:(NSUInteger) index;
+
 @end

--- a/GeoFeatures/GFMultiPoint.h
+++ b/GeoFeatures/GFMultiPoint.h
@@ -184,7 +184,7 @@
 
     /** Sets the GFPoint at the given index.
      *
-     * @param aPoint The GFPoint with which to replace the GFPoint at index index in the GFMutableMultiPoint. This value must not be nil.
+     * @param aPoint The GFPoint with which to replace the GFPoint at index in the GFMutableMultiPoint. This value must not be nil.
      * @param index  The index of the GFPoint to be replaced. This value must not exceed the bounds of the GFMutableMultiPoint.
      *
      * Example:

--- a/GeoFeatures/GFMultiPoint.mm
+++ b/GeoFeatures/GFMultiPoint.mm
@@ -233,4 +233,22 @@ namespace gf = geofeatures;
         _multiPoint.erase(_multiPoint.begin() + index);
     }
 
+    - (void) setObject: (GFPoint *) aPoint atIndexedSubscript: (NSUInteger) index {
+
+        if (aPoint == nil) {
+            [NSException raise: NSInvalidArgumentException format: @"aPoint can not be nil."];
+        }
+        if (index > _multiPoint.size()) {
+            [NSException raise: NSRangeException format: @"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _multiPoint.size()];
+        }
+        // Note: geofeatures::<collection type> classes will throw an "Objective-C"
+        // NSMallocException if they fail to allocate memory for the operation below
+        // so no C++ exception block is required.
+        if (index == _multiPoint.size()) {
+            _multiPoint.push_back([aPoint cppConstPointReference]);
+        } else {
+            _multiPoint[index] = [aPoint cppConstPointReference];
+        }
+    }
+
 @end

--- a/GeoFeatures/GFMultiPolygon.h
+++ b/GeoFeatures/GFMultiPolygon.h
@@ -199,4 +199,26 @@
      */
     - (void) removeGeometryAtIndex: (NSUInteger) index;
 
+    /** Sets the GFPolygon at the given index.
+     *
+     * @param aPolygon The GFPolygon with which to replace the GFPolygon at index in the GFMutableMultiPolygon. This value must not be nil.
+     * @param index  The index of the GFPolygon to be replaced. This value must not exceed the bounds of the GFMutableMultiPolygon.
+     *
+     * Example:
+     *
+     * @code
+     * {
+     *    GFMutableMultiPolygon * multiPolygon = [[GFMutableMultiPolygon alloc] init];
+     *
+     *    multiPolygon[0] = [[GFPolygon alloc] initWithWKT: @"POLYGON((0 0,0 90,90 90,90 0,0 0))"];
+     *    multiPolygon[1] = [[GFPolygon alloc] initWithWKT: @"POLYGON((0 0,0 80,80 80,80 0,0 0))"];
+     * }
+     * @endcode
+     *
+     * @throws NSException If index is beyond the end of the collection (that is, if index is greater than or equal to the value returned by count), an NSRangeException is raised.
+     *
+     * @since 1.3.0
+     */
+    - (void) setObject: (GFPolygon *) aPolygon atIndexedSubscript:(NSUInteger) index;
+
 @end

--- a/GeoFeatures/GFMultiPolygon.mm
+++ b/GeoFeatures/GFMultiPolygon.mm
@@ -242,4 +242,22 @@ namespace gf = geofeatures;
         _multiPolygon.erase(_multiPolygon.begin() + index);
     }
 
+    - (void) setObject: (GFPolygon *) aPolygon atIndexedSubscript: (NSUInteger) index {
+
+        if (aPolygon == nil) {
+            [NSException raise: NSInvalidArgumentException format: @"aPolygon can not be nil."];
+        }
+        if (index > _multiPolygon.size()) {
+            [NSException raise: NSRangeException format: @"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _multiPolygon.size()];
+        }
+        // Note: geofeatures::<collection type> classes will throw an "Objective-C"
+        // NSMallocException if they fail to allocate memory for the operation below
+        // so no C++ exception block is required.
+        if (index == _multiPolygon.size()) {
+            _multiPolygon.push_back([aPolygon cppConstPolygonReference]);
+        } else {
+            _multiPolygon[index] = [aPolygon cppConstPolygonReference];
+        }
+    }
+
 @end

--- a/GeoFeatures/GFPoint.mm
+++ b/GeoFeatures/GFPoint.mm
@@ -128,6 +128,10 @@ namespace gf = geofeatures;
         return self;
     }
 
+    - (const gf::Point &) cppConstPointReference {
+        return _point;
+    }
+
     - (gf::GeometryVariant) cppGeometryVariant {
         return gf::GeometryVariant(_point);
     }

--- a/GeoFeatures/GFRing.h
+++ b/GeoFeatures/GFRing.h
@@ -134,4 +134,29 @@
      */
     - (void) removePointAtIndex: (NSUInteger) index;
 
+    /** Sets the GFPoint at the given index.
+     *
+     * @param aPoint The GFPoint with which to replace the GFPoint at index in the GFMutableRing. This value must not be nil.
+     * @param index  The index of the GFPoint to be replaced. This value must not exceed the bounds of the GFMutableRing.
+     *
+     * Example:
+     *
+     * @code
+     * {
+     *    GFMutableRing * ring = [[GFMutableRing alloc] init];
+     *
+     *   ring[0] = [[GFPoint alloc] initWithWKT: @"POINT(20 0)"];
+     *   ring[1] = [[GFPoint alloc] initWithWKT: @"POINT(20 10)"];
+     *   ring[2] = [[GFPoint alloc] initWithWKT: @"POINT(40 10)"];
+     *   ring[3] = [[GFPoint alloc] initWithWKT: @"POINT(40 0)"];
+     *   ring[4] = [[GFPoint alloc] initWithWKT: @"POINT(20 0)"];
+     * }
+     * @endcode
+     *
+     * @throws NSException If index is beyond the end of the collection (that is, if index is greater than or equal to the value returned by count), an NSRangeException is raised.
+     *
+     * @since 1.3.0
+     */
+    - (void) setObject: (GFPoint *) aPoint atIndexedSubscript:(NSUInteger) index;
+
 @end

--- a/GeoFeatures/GFRing.mm
+++ b/GeoFeatures/GFRing.mm
@@ -280,4 +280,22 @@ namespace gf = geofeatures;
         _ring.erase(_ring.begin() + index);
     }
 
+    - (void) setObject: (GFPoint *) aPoint atIndexedSubscript: (NSUInteger) index {
+
+        if (aPoint == nil) {
+            [NSException raise: NSInvalidArgumentException format: @"aPoint can not be nil."];
+        }
+        if (index > _ring.size()) {
+            [NSException raise: NSRangeException format: @"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _ring.size()];
+        }
+        // Note: geofeatures::<collection type> classes will throw an "Objective-C"
+        // NSMallocException if they fail to allocate memory for the operation below
+        // so no C++ exception block is required.
+        if (index == _ring.size()) {
+            _ring.push_back([aPoint cppConstPointReference]);
+        } else {
+            _ring[index] = [aPoint cppConstPointReference];
+        }
+    }
+
 @end

--- a/GeoFeatures/Internal/GFPoint+Protected.hpp
+++ b/GeoFeatures/Internal/GFPoint+Protected.hpp
@@ -39,6 +39,8 @@ namespace  gf = geofeatures;
      */
     - (instancetype) initWithCPPPoint: (gf::Point) aPoint;
 
+    - (const gf::Point &) cppConstPointReference;
+
 @end
 
 #endif // __GFPointProtected_hpp


### PR DESCRIPTION
### Adding Indexed Subscripting for Mutable types
- Adding - (void) setObject:atIndexedSubscript: method and header docs to all collection type geometries.
- Implemented - (void) setObject:atIndexedSubscript: method for all collection type geometries.
- Added all tests for - (void) setObject:atIndexedSubscript: to all collection type geometries.
### Modified GFPoint to support Indexed Subscripting
- Added - (const gf::Point &) cppConstPointReference method to GFPoint+Protected.hpp to support - (void) setObject:atIndexedSubscript: .
- Implemented - (const gf::Point &) cppConstPointReference in GFPoint.mm to support - (void) setObject:atIndexedSubscript:
