### PR TITLE
Adding typed params to Indexed subscripting.

### DIFF
--- a/GeoFeatures/GFLineString.h
+++ b/GeoFeatures/GFLineString.h
@@ -144,7 +144,7 @@
      *
      * @since 1.1.0
      */
-    - (id) objectAtIndexedSubscript: (NSUInteger) index;
+    - (GFPoint *) objectAtIndexedSubscript: (NSUInteger) index;
 
 @end
 

--- a/GeoFeatures/GFLineString.mm
+++ b/GeoFeatures/GFLineString.mm
@@ -125,7 +125,7 @@ namespace gf = geofeatures;
 
 #pragma mark - Indexed Subscripting
 
-    - (id) objectAtIndexedSubscript: (NSUInteger) index {
+    - (GFPoint *) objectAtIndexedSubscript: (NSUInteger) index {
 
         auto size = _lineString.size();
 

--- a/GeoFeatures/GFMultiLineString.h
+++ b/GeoFeatures/GFMultiLineString.h
@@ -151,7 +151,7 @@
      *
      * @since 1.1.0
      */
-    - (id) objectAtIndexedSubscript: (NSUInteger) index;
+    - (GFLineString *) objectAtIndexedSubscript: (NSUInteger) index;
 
 @end
 

--- a/GeoFeatures/GFMultiLineString.mm
+++ b/GeoFeatures/GFMultiLineString.mm
@@ -137,7 +137,7 @@ namespace gf = geofeatures;
 
 #pragma mark - Indexed Subscripting
 
-    - (id) objectAtIndexedSubscript: (NSUInteger) index {
+    - (GFLineString *) objectAtIndexedSubscript: (NSUInteger) index {
 
         auto size = _multiLineString.size();
 

--- a/GeoFeatures/GFMultiPoint.h
+++ b/GeoFeatures/GFMultiPoint.h
@@ -144,7 +144,7 @@
      *
      * @since 1.1.0
      */
-    - (id) objectAtIndexedSubscript: (NSUInteger) index;
+    - (GFPoint *) objectAtIndexedSubscript: (NSUInteger) index;
 
 @end
 

--- a/GeoFeatures/GFMultiPoint.mm
+++ b/GeoFeatures/GFMultiPoint.mm
@@ -133,7 +133,7 @@ namespace gf = geofeatures;
 
 #pragma mark - Indexed Subscripting
 
-    - (id) objectAtIndexedSubscript: (NSUInteger) index {
+    - (GFPoint *) objectAtIndexedSubscript: (NSUInteger) index {
 
         auto size = _multiPoint.size();
 

--- a/GeoFeatures/GFMultiPolygon.h
+++ b/GeoFeatures/GFMultiPolygon.h
@@ -161,7 +161,7 @@
      *
      * @since 1.1.0
      */
-    - (id) objectAtIndexedSubscript: (NSUInteger) index;
+    - (GFPolygon *) objectAtIndexedSubscript: (NSUInteger) index;
 
 @end
 

--- a/GeoFeatures/GFMultiPolygon.mm
+++ b/GeoFeatures/GFMultiPolygon.mm
@@ -145,7 +145,7 @@ namespace gf = geofeatures;
 
 #pragma mark - Indexed Subscripting
 
-    - (id) objectAtIndexedSubscript: (NSUInteger) index {
+    - (GFPolygon *) objectAtIndexedSubscript: (NSUInteger) index {
 
         auto size = _multiPolygon.size();
 

--- a/GeoFeatures/GFRing.mm
+++ b/GeoFeatures/GFRing.mm
@@ -152,7 +152,7 @@ namespace gf = geofeatures;
 
 #pragma mark - Indexed Subscripting
 
-    - (id) objectAtIndexedSubscript: (NSUInteger) index {
+    - (GFPoint *) objectAtIndexedSubscript: (NSUInteger) index {
 
         const auto size = _ring.size();
 


### PR DESCRIPTION
- Adding specific types to the objectAtIndexedSubscript: methods where allowed by the compiler to allow the compiler to give warnings when the subscripting is not being used with the correct classes.
