### PR TITLE
Mutable corrections

### DIFF
--- a/Example/Tests/Model/GFMutablePolygonTests.m
+++ b/Example/Tests/Model/GFMutablePolygonTests.m
@@ -37,7 +37,7 @@
     - (void) testSetOuterRing_WithValidRing {
         GFMutablePolygon * polygon = [[GFMutablePolygon alloc] init];
 
-        [polygon setOutRing: [[GFRing alloc] initWithWKT: @"LINESTRING(100 0,200 100,200 0,100 1,100 0)"]];
+        [polygon setOuterRing: [[GFRing alloc] initWithWKT: @"LINESTRING(100 0,200 100,200 0,100 1,100 0)"]];
 
         XCTAssertEqualObjects([polygon toWKTString], @"POLYGON((100 0,200 100,200 0,100 1,100 0))");
     }
@@ -45,7 +45,7 @@
     - (void) testSetOuterRing_WithEmptyRing {
         GFMutablePolygon * polygon = [[GFMutablePolygon alloc] init];
 
-        [polygon setOutRing: [[GFRing alloc] initWithWKT: @"LINESTRING()"]];
+        [polygon setOuterRing: [[GFRing alloc] initWithWKT: @"LINESTRING()"]];
 
         XCTAssertEqualObjects([polygon toWKTString], @"POLYGON(())");
     }
@@ -53,7 +53,7 @@
     - (void) testSetOuterRing_WithNilRing {
         GFMutablePolygon * polygon = [[GFMutablePolygon alloc] init];
 
-        XCTAssertThrowsSpecificNamed([polygon setOutRing: nil], NSException, NSInvalidArgumentException);
+        XCTAssertThrowsSpecificNamed([polygon setOuterRing: nil], NSException, NSInvalidArgumentException);
     }
 
     - (void) testInnerRings_WithValidRings {
@@ -62,7 +62,7 @@
                 [[GFRing alloc] initWithWKT: @"LINESTRING(100.2 0.2,100.8 0.2,100.8 0.8,100.2 0.8,100.2 0.2)"]
         ]];
 
-        [polygon setOutRing: [[GFRing alloc] initWithWKT: @"LINESTRING(100 0,200 100,200 0,100 1,100 0)"]];
+        [polygon setOuterRing: [[GFRing alloc] initWithWKT: @"LINESTRING(100 0,200 100,200 0,100 1,100 0)"]];
         [polygon setInnerRings: geometryCollection];
 
         XCTAssertEqualObjects([polygon toWKTString], @"POLYGON((100 0,200 100,200 0,100 1,100 0),(100.2 0.2,100.2 0.8,100.8 0.8,100.8 0.2,100.2 0.2))");

--- a/GeoFeatures/GFGeometryCollection.h
+++ b/GeoFeatures/GFGeometryCollection.h
@@ -141,7 +141,7 @@
      */
     - (void) insertGeometry: (id) aGeometry atIndex: (NSUInteger) index;
 
-    /** Empties the GFMutableMultiPolygon of all its GFGeometries.
+    /** Empties the GFMutableGeometryCollection of all its GFGeometries.
      */
     - (void) removeAllGeometries;
 

--- a/GeoFeatures/GFGeometryCollection.h
+++ b/GeoFeatures/GFGeometryCollection.h
@@ -121,7 +121,7 @@
 /**
  * @class       GFMutableGeometryCollection
  *
- * @brief       A mutable version GFGeometryCollection.
+ * @brief       A mutable version of GFGeometryCollection.
  *
  * @author      Tony Stone
  * @date        9/26/15

--- a/GeoFeatures/GFLineString.h
+++ b/GeoFeatures/GFLineString.h
@@ -152,7 +152,7 @@
 /**
  * @class       GFMutableLineString
  *
- * @brief       A mutable version GFLineString.
+ * @brief       A mutable version of GFLineString.
  *
  * @author      Tony Stone
  * @date        9/23/15

--- a/GeoFeatures/GFMultiLineString.h
+++ b/GeoFeatures/GFMultiLineString.h
@@ -158,7 +158,7 @@
 /**
  * @class       GFMutableMultiLineString
  *
- * @brief       A mutable version GFMultiLineString.
+ * @brief       A mutable version of GFMultiLineString.
  *
  * @author      Tony Stone
  * @date        9/24/15

--- a/GeoFeatures/GFMultiPoint.h
+++ b/GeoFeatures/GFMultiPoint.h
@@ -152,7 +152,7 @@
 /**
  * @class       GFMutableMultiPoint
  *
- * @brief       A mutable version GFMultiPoint.
+ * @brief       A mutable version of GFMultiPoint.
  *
  * @author      Tony Stone
  * @date        9/24/15

--- a/GeoFeatures/GFMultiPolygon.h
+++ b/GeoFeatures/GFMultiPolygon.h
@@ -169,7 +169,7 @@
 /**
  * @class       GFMutableMultiPolygon
  *
- * @brief       A mutable version GFMultiPolygon.
+ * @brief       A mutable version of GFMultiPolygon.
  *
  * @author      Tony Stone
  * @date        9/24/15

--- a/GeoFeatures/GFPolygon.h
+++ b/GeoFeatures/GFPolygon.h
@@ -117,7 +117,7 @@
     /**
      * Set the outer GFRing of this GFMutablePolygon.
      */
-    - (void) setOutRing: (GFRing *) outerRing;
+    - (void) setOuterRing: (GFRing *) outerRing;
 
     /**
      * Set the inner GFRings of this GFMutablePolygon.

--- a/GeoFeatures/GFPolygon.mm
+++ b/GeoFeatures/GFPolygon.mm
@@ -147,7 +147,7 @@ namespace gf = geofeatures;
 
 @implementation GFMutablePolygon
 
-    - (void) setOutRing: (GFRing *) outerRing {
+    - (void) setOuterRing: (GFRing *) outerRing {
 
         if (outerRing == nil) {
             [NSException raise: NSInvalidArgumentException format: @"outerRing cannot be nil."];

--- a/GeoFeatures/GFRing.h
+++ b/GeoFeatures/GFRing.h
@@ -104,7 +104,7 @@
 /**
  * @class       GFMutableRing
  *
- * @brief       A mutable version GFRing.
+ * @brief       A mutable version of GFRing.
  *
  * @author      Tony Stone
  * @date        9/24/15


### PR DESCRIPTION
### Corrections in Mutable Classes
- Grammatical corrections in @brief section of Mutable classes. 
### Update GFMutablePolygon
- Renamed setOutRing: to setOuterRing:
### Update GFMutableGeometryCollection
- Correct comment in removeAlGeometries changing GFMutableMultiPolygon to GFMutableGeometryCollection.
