### PR TITLE
Optimize collection accessors

### DIFF
--- a/GeoFeatures/GFGeometryCollection.mm
+++ b/GeoFeatures/GFGeometryCollection.mm
@@ -93,9 +93,7 @@ namespace gf = geofeatures;
 
     - (id) geometryAtIndex: (NSUInteger) index {
 
-        auto size = _geometryCollection.size();
-
-        if (size == 0 || index > (size -1)) {
+        if (index >= _geometryCollection.size()) {
             [NSException raise:NSRangeException format:@"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _geometryCollection.size()];
         }
         //
@@ -111,7 +109,7 @@ namespace gf = geofeatures;
     - (id) firstGeometry {
 
         if (!_geometryCollection.empty()) {
-            return boost::apply_visitor(gf::GFInstanceFromVariant(), _geometryCollection.front());
+            return boost::apply_visitor(gf::GFInstanceFromVariant(), *_geometryCollection.begin());
         }
         return nil;
     }
@@ -119,7 +117,7 @@ namespace gf = geofeatures;
     - (id) lastGeometry {
 
         if (!_geometryCollection.empty()) {
-            return boost::apply_visitor(gf::GFInstanceFromVariant(), _geometryCollection.back());
+            return boost::apply_visitor(gf::GFInstanceFromVariant(), *(_geometryCollection.end() - 1));
         }
         return nil;
     }
@@ -132,9 +130,7 @@ namespace gf = geofeatures;
 
     - (id) objectAtIndexedSubscript: (NSUInteger) index {
 
-        auto size = _geometryCollection.size();
-
-        if (size == 0 || index > (size -1)) {
+        if (index >= _geometryCollection.size()) {
             [NSException raise: NSRangeException format: @"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _geometryCollection.size()];
         }
         //

--- a/GeoFeatures/GFLineString.mm
+++ b/GeoFeatures/GFLineString.mm
@@ -92,9 +92,7 @@ namespace gf = geofeatures;
 
     - (GFPoint *) pointAtIndex: (NSUInteger) index {
 
-        auto size = _lineString.size();
-        
-        if (size == 0 || index > (size -1)) {
+        if (index >= _lineString.size()) {
             [NSException raise:NSRangeException format:@"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _lineString.size()];
         }
         //
@@ -112,7 +110,7 @@ namespace gf = geofeatures;
         if (_lineString.empty()) {
             return nil;
         }
-        return [[GFPoint alloc] initWithCPPPoint: _lineString.front()];
+        return [[GFPoint alloc] initWithCPPPoint: *_lineString.begin()];
     }
 
     - (GFPoint *) lastPoint {
@@ -120,16 +118,14 @@ namespace gf = geofeatures;
         if (_lineString.empty()) {
             return nil;
         }
-        return [[GFPoint alloc] initWithCPPPoint: _lineString.back()];
+        return [[GFPoint alloc] initWithCPPPoint: *(_lineString.end() - 1)];
     }
 
 #pragma mark - Indexed Subscripting
 
     - (GFPoint *) objectAtIndexedSubscript: (NSUInteger) index {
 
-        auto size = _lineString.size();
-
-        if (size == 0 || index > (size -1)) {
+        if (index >= _lineString.size()) {
             [NSException raise: NSRangeException format: @"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _lineString.size()];
         }
         //

--- a/GeoFeatures/GFMultiLineString.mm
+++ b/GeoFeatures/GFMultiLineString.mm
@@ -104,9 +104,7 @@ namespace gf = geofeatures;
 
     - (GFLineString *) geometryAtIndex:(NSUInteger)index {
 
-        auto size = _multiLineString.size();
-
-        if (size == 0 || index > (size -1)) {
+        if (index >= _multiLineString.size()) {
             [NSException raise:NSRangeException format:@"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _multiLineString.size()];
         }
         //
@@ -124,7 +122,7 @@ namespace gf = geofeatures;
         if (_multiLineString.empty()) {
             return nil;
         }
-        return [[GFLineString alloc] initWithCPPLineString: _multiLineString.front()];
+        return [[GFLineString alloc] initWithCPPLineString: *_multiLineString.begin()];
     }
 
     - (GFLineString *) lastGeometry {
@@ -132,16 +130,14 @@ namespace gf = geofeatures;
         if (_multiLineString.empty()) {
             return nil;
         }
-        return [[GFLineString alloc] initWithCPPLineString: _multiLineString.back()];
+        return [[GFLineString alloc] initWithCPPLineString: *(_multiLineString.end() - 1)];
     }
 
 #pragma mark - Indexed Subscripting
 
     - (GFLineString *) objectAtIndexedSubscript: (NSUInteger) index {
 
-        auto size = _multiLineString.size();
-
-        if (size == 0 || index > (size -1)) {
+        if (index >= _multiLineString.size()) {
             [NSException raise: NSRangeException format: @"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _multiLineString.size()];
         }
         //

--- a/GeoFeatures/GFMultiPoint.mm
+++ b/GeoFeatures/GFMultiPoint.mm
@@ -100,9 +100,7 @@ namespace gf = geofeatures;
 
     - (GFPoint *) geometryAtIndex: (NSUInteger) index {
 
-        auto size = _multiPoint.size();
-
-        if (size == 0 || index > (size -1)) {
+        if (index >= _multiPoint.size()) {
             [NSException raise:NSRangeException format:@"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _multiPoint.size()];
         }
         //
@@ -120,7 +118,7 @@ namespace gf = geofeatures;
         if (_multiPoint.empty()) {
             return nil;
         }
-        return [[GFPoint alloc] initWithCPPPoint: _multiPoint.front()];
+        return [[GFPoint alloc] initWithCPPPoint: *_multiPoint.begin()];
     }
 
     - (GFPoint *) lastGeometry {
@@ -128,16 +126,14 @@ namespace gf = geofeatures;
         if (_multiPoint.empty()) {
             return nil;
         }
-        return [[GFPoint alloc] initWithCPPPoint: _multiPoint.back()];
+        return [[GFPoint alloc] initWithCPPPoint: *(_multiPoint.end() - 1)];
     }
 
 #pragma mark - Indexed Subscripting
 
     - (GFPoint *) objectAtIndexedSubscript: (NSUInteger) index {
 
-        auto size = _multiPoint.size();
-
-        if (size == 0 || index > (size -1)) {
+        if (index >= _multiPoint.size()) {
             [NSException raise: NSRangeException format: @"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _multiPoint.size()];
         }
         //

--- a/GeoFeatures/GFMultiPolygon.mm
+++ b/GeoFeatures/GFMultiPolygon.mm
@@ -112,9 +112,7 @@ namespace gf = geofeatures;
 
     - (GFPolygon *) geometryAtIndex: (NSUInteger) index {
 
-        auto size = _multiPolygon.size();
-
-        if (size == 0 || index > (size -1)) {
+        if (index >= _multiPolygon.size()) {
             [NSException raise:NSRangeException format:@"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) (unsigned long) (unsigned long) _multiPolygon.size()];
         }
         //
@@ -132,7 +130,7 @@ namespace gf = geofeatures;
         if (_multiPolygon.empty()) {
             return nil;
         }
-        return [[GFPolygon alloc] initWithCPPPolygon: _multiPolygon.front()];
+        return [[GFPolygon alloc] initWithCPPPolygon: *_multiPolygon.begin()];
     }
 
     - (GFPolygon *) lastGeometry {
@@ -140,16 +138,14 @@ namespace gf = geofeatures;
         if (_multiPolygon.empty()) {
             return nil;
         }
-        return [[GFPolygon alloc] initWithCPPPolygon: _multiPolygon.back()];
+        return [[GFPolygon alloc] initWithCPPPolygon: *(_multiPolygon.end() - 1)];
     }
 
 #pragma mark - Indexed Subscripting
 
     - (GFPolygon *) objectAtIndexedSubscript: (NSUInteger) index {
 
-        auto size = _multiPolygon.size();
-
-        if (size == 0 || index > (size -1)) {
+        if (index >= _multiPolygon.size()) {
             [NSException raise: NSRangeException format: @"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _multiPolygon.size()];
         }
         //

--- a/GeoFeatures/GFRing.mm
+++ b/GeoFeatures/GFRing.mm
@@ -119,9 +119,7 @@ namespace gf = geofeatures;
 
     - (GFPoint *) pointAtIndex: (NSUInteger) index {
 
-        const auto size = _ring.size();
-
-        if (size == 0 || index > (size -1)) {
+        if (index >= _ring.size()) {
             [NSException raise: NSRangeException format: @"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _ring.size()];
         }
         //
@@ -139,7 +137,7 @@ namespace gf = geofeatures;
         if (_ring.empty()) {
             return nil;
         }
-        return [[GFPoint alloc] initWithCPPPoint: _ring.front()];
+        return [[GFPoint alloc] initWithCPPPoint: *_ring.begin()];
     }
 
     - (GFPoint *) lastPoint {
@@ -147,16 +145,14 @@ namespace gf = geofeatures;
         if (_ring.empty()) {
             return nil;
         }
-        return [[GFPoint alloc] initWithCPPPoint: _ring.back()];
+        return [[GFPoint alloc] initWithCPPPoint: *(_ring.end() - 1)];
     }
 
 #pragma mark - Indexed Subscripting
 
     - (GFPoint *) objectAtIndexedSubscript: (NSUInteger) index {
 
-        const auto size = _ring.size();
-
-        if (size == 0 || index > (size -1)) {
+        if (index >= _ring.size()) {
             [NSException raise: NSRangeException format: @"Index %li is beyond bounds [0, %li].", (unsigned long) index, (unsigned long) _ring.size()];
         }
         //


### PR DESCRIPTION
### Updated all collection classes
- Simplified -<type>AtIndex range check to index >= size().
- Simplified -objectAtIndexSubscript: range check to using index >= size().
- Change -firstPoint from using front() to *<type>.begin() to gain the noexcept guarantee and avoid the extra call to empty().
- Change -lastPoint from using back() to *(<type>.end() -1) to gain the noexcept guarantee and avoid the extra call to empty().
