### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,20 @@
 language: objective-c
-xcode_workspace: Example/GeoFeatures.xcworkspace
-xcode_scheme: GeoFeatures-Example
+os: osx
 osx_image: xcode7.3
 
 before_install:
-#    - brew install xctool
-    - git clone https://github.com/facebook/xctool.git
-    - gem install cocoapods --quiet
-    - pod --version
-    - pod setup --silent
-    - pod repo update --silent
-    - IPHONE_SIMULATOR_ID=$(xcrun instruments -s | grep -o "iPhone 6 (9.1) \[.*\]" | grep -o "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")
-    - MAC_SIMULATOR_ID=$(xcrun instruments -s | grep -o "Travis’s Mac\[.*\]" | grep -o "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")
-    
+- gem install xcpretty -N --no-ri --no-rdoc
+
 env:
-  - COCOAPODS_DISABLE_DETERMINISTIC_UUIDS=1
-
+global:
+- COCOAPODS_DISABLE_DETERMINISTIC_UUIDS=1
+matrix:
+- BUILD_TARGET="-scheme GeoFeatures-iOS-Example -sdk iphonesimulator"
+- BUILD_TARGET="-scheme GeoFeatures-OSX-Example -sdk macosx"
 script:
-  - travis_wait pod lib lint
-  
-  - travis_wait xctool/xctool.sh  -workspace Example/GeoFeatures.xcworkspace -scheme GeoFeatures-iOS-Example -sdk iphonesimulator GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES clean build
-  
-  - open -a "simulator" --args -CurrentDeviceUDID $IPHONE_SIMULATOR_ID
-  - travis_wait xctool/xctool.sh  -workspace Example/GeoFeatures.xcworkspace -scheme GeoFeatures-iOS-Example -sdk iphonesimulator GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES test
 
-  - travis_wait xctool/xctool.sh  -workspace Example/GeoFeatures.xcworkspace -scheme GeoFeatures-OSX-Example -sdk macosx GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES clean build
-  
-  - open -a "simulator" --args -CurrentDeviceUDID $MAC_SIMULATOR_ID
-  - travis_wait xctool/xctool.sh  -workspace Example/GeoFeatures.xcworkspace -scheme GeoFeatures-OSX-Example -sdk macosx GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES test
+- set -o pipefail
+- xcodebuild clean test -workspace Example/GeoFeatures.xcworkspace $BUILD_TARGET GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+- bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,18 @@ os: osx
 osx_image: xcode7.3
 
 before_install:
-- gem install xcpretty -N --no-ri --no-rdoc
+    - gem install xcpretty -N --no-ri --no-rdoc
 
 env:
-global:
-- COCOAPODS_DISABLE_DETERMINISTIC_UUIDS=1
-matrix:
-- BUILD_TARGET="-scheme GeoFeatures-iOS-Example -sdk iphonesimulator"
-- BUILD_TARGET="-scheme GeoFeatures-OSX-Example -sdk macosx"
-script:
+    global:
+        - COCOAPODS_DISABLE_DETERMINISTIC_UUIDS=1
+    matrix:
+        - MATRIX_TARGET="-scheme GeoFeatures-iOS-Example -sdk iphonesimulator"
+        - MATRIX_TARGET="-scheme GeoFeatures-OSX-Example -sdk macosx"
 
-- set -o pipefail
-- xcodebuild clean test -workspace Example/GeoFeatures.xcworkspace $BUILD_TARGET GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty
+script:
+    - set -o pipefail
+    - xcodebuild clean test -workspace Example/GeoFeatures.xcworkspace $MATRIX_TARGET GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty
 
 after_success:
-- bash <(curl -s https://codecov.io/bash)
+    - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
- Working around travis timeout issue travis-ci/travis-ci#4906 and  travis-ci/travis-ci#5743.
- Switching to xcodebuild from xctool (note, xctool is dropping support for building).
- Adding set -o pipefail and piping output to xcpretty.
- Creating a matrix build to limit the runtime of the builds.
- Dropping redundant xcode_workspace: and xcode_scheme: tags.
