### PR TITLE
Adding variable substitution for the swift version number.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - WORKSPACE=Example/GeoFeatures.xcworkspace
     - SCHEME=GeoFeatures-Example
     - TEST_SDK=iphonesimulator
+    - SWIFT_VERSION=3.1.1
 
 matrix:
   include:
@@ -92,9 +93,9 @@ before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       sudo apt-get update -y
-      wget https://swift.org/builds/swift-3.1-release/ubuntu1404/swift-3.1-RELEASE/swift-3.1-RELEASE-ubuntu14.04.tar.gz
-      tar xzvf swift-3.1-RELEASE-ubuntu14.04.tar.gz
-      export PATH=swift-3.1-RELEASE-ubuntu14.04/usr/bin:$PATH
+      wget https://swift.org/builds/swift-$SWIFT_VERSION-release/ubuntu1404/swift-$SWIFT_VERSION-RELEASE/swift-$SWIFT_VERSION-RELEASE-ubuntu14.04.tar.gz
+      tar xzvf swift-$SWIFT_VERSION-RELEASE-ubuntu14.04.tar.gz
+      export PATH=swift-$SWIFT_VERSION-RELEASE-ubuntu14.04/usr/bin:$PATH
       sudo apt-get -y install clang-3.8 lldb-3.8 libicu-dev
     fi
 


### PR DESCRIPTION
Adding variable substitution for the swift version number on Linux builds and updating version to 3.1.1.