### PR TITLE
Added mkMapOverlays support to GeometryCollections

### DIFF
--- a/Example/Tests/Model/GFGeometryCollectionTests.m
+++ b/Example/Tests/Model/GFGeometryCollectionTests.m
@@ -224,6 +224,24 @@ static void __attribute__((constructor)) staticInitializer() {
                 @"GEOMETRYCOLLECTION(POLYGON((0 0,0 90,90 90,90 0,0 0)),POLYGON((120 0,120 90,210 90,210 0,120 0)),LINESTRING(40 50,40 140),LINESTRING(160 50,160 140),POINT(60 50),POINT(60 140),POINT(40 140))");
     }
 
+#pragma mark - Test mapOverlays
+
+- (void) testMapOverlays {
+
+    NSArray * mapOverlays = [[[GFGeometryCollection alloc] initWithGeoJSONGeometry: geoJSON]  mkMapOverlays];
+
+    XCTAssertNotNil (mapOverlays);
+    XCTAssertTrue   ([mapOverlays count] == 11);
+
+    XCTAssertTrue   ([[mapOverlays objectAtIndex: 2] isKindOfClass: [MKPolygon class]]);
+
+    MKPolygon * polygon = (MKPolygon *) [mapOverlays objectAtIndex: 2];
+
+    XCTAssertTrue   ([polygon pointCount] == 5);
+    XCTAssertTrue   ([[polygon interiorPolygons] count] == 1);
+
+}
+
 #pragma mark - Test count
 
     - (void) testCount_WithEmptyGeometryCollection {

--- a/GeoFeatures/GFGeometryCollection.mm
+++ b/GeoFeatures/GFGeometryCollection.mm
@@ -228,6 +228,18 @@ namespace gf = geofeatures;
         return gf::GeometryPtrVariant(&_geometryCollection);
     }
 
+#pragma mark - MapKit
+
+    - (NSArray *) mkMapOverlays {
+        NSMutableArray * mkMapOverlays = [[NSMutableArray alloc] init];
+
+        for (int idx = 0; idx < self.count; ++idx) {
+            GFGeometry * geometry = [self geometryAtIndex: idx];
+            [mkMapOverlays addObjectsFromArray: geometry.mkMapOverlays];
+        }
+        return mkMapOverlays;
+    }
+
 @end
 
 

--- a/GeoFeatures/GFGeometryCollection.mm
+++ b/GeoFeatures/GFGeometryCollection.mm
@@ -410,8 +410,3 @@ NSArray * geofeatures::GFGeometryCollection::geoJSONGeometriesWithGeometryCollec
     }
     return geometries;
 }
-
-//id <MKOverlay> geofeatures::GFGeometryCollection::mkOverlayWithGeometryCollection(const geofeatures::GeometryCollection<> & geometryCollection) {
-//   return nil;
-//}
-


### PR DESCRIPTION
Calling `mkMapOverlays` on an instance of `GFGeometryCollections` will result on an exception, raised by the [base class implementation of that method](https://github.com/tonystone/geofeatures/blob/867e26e1b38fa92d938b04ebad25b36274e74b47/GeoFeatures/GFGeometry.mm#L390).

The change on this PR implements the method on `GFGeometryCollections`